### PR TITLE
ci: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Install Hugo (extended)
@@ -31,7 +31,7 @@ jobs:
           extended: true
       - name: Build
         run: hugo --minify --gc --baseURL "https://theartofpostgresql.com/"
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: ./docs
 
@@ -43,4 +43,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Fixes the Node.js 20 deprecation warnings from [run #28880608439](https://github.com/dimitri/taop.xyz/actions/runs/28880608439).

## Root cause

Three actions internally targeted Node.js 20:

| Action | Before | After | Node runtime |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v7` | node20 → node24 |
| `actions/upload-pages-artifact` | `@v3` | `@v5` | node20 (via upload-artifact@v4) → composite |
| `actions/deploy-pages` | `@v4` | `@v5` | node20 → node24 |

`peaceiris/actions-hugo@v3` (latest) is unaffected — it just downloads a binary, no Node runtime dependency.

## Verification

Checked each target version's `action.yml` via GitHub API to confirm the `using:` field before bumping.