### PR TITLE
fix(hero): responsive logo and CTAs on mobile

### DIFF
--- a/layouts/partials/book/caroussel.html
+++ b/layouts/partials/book/caroussel.html
@@ -1,11 +1,10 @@
 <div class="welcome_slider">
-  <div style="position: relative; min-height: 100vh; overflow: hidden;">
+  <div class="hero-slide">
     <img src="/images/demo/slide.jpg" alt=""
          style="position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; object-position: center; z-index: 0;">
-    <div style="position: relative; z-index: 1; min-height: 100vh; max-width: 820px; margin: 0 auto;
-                display: flex; flex-flow: column nowrap; justify-content: center; align-items: center;">
-      <img src="/images/demo/welcome_logo.png" alt="" style="max-width: 812px;">
-      <p style="margin: 40px 0 0 0; display: flex; gap: 24px; flex-wrap: wrap; justify-content: center;">
+    <div class="hero-content">
+      <img src="/images/demo/welcome_logo.png" alt="The Art of PostgreSQL" class="hero-logo">
+      <p class="hero-cta">
         <a class="button button_large" href="https://sales.theartofpostgresql.com/the-art-of-postgresql-book/">
           Buy the Book
         </a>

--- a/layouts/partials/index/caroussel.html
+++ b/layouts/partials/index/caroussel.html
@@ -1,11 +1,10 @@
 <div class="welcome_slider">
-  <div style="position: relative; min-height: 100vh; overflow: hidden;">
+  <div class="hero-slide">
     <img src="/images/demo/slide.jpg" alt=""
          style="position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; object-position: center; z-index: 0;">
-    <div style="position: relative; z-index: 1; min-height: 100vh; max-width: 820px; margin: 0 auto;
-                display: flex; flex-flow: column nowrap; justify-content: center; align-items: center;">
-      <img src="/images/demo/welcome_logo.png" alt="" style="max-width: 812px;">
-      <p style="margin: 40px 0 0 0; display: flex; gap: 24px; flex-wrap: wrap; justify-content: center;">
+    <div class="hero-content">
+      <img src="/images/demo/welcome_logo.png" alt="The Art of PostgreSQL" class="hero-logo">
+      <p class="hero-cta">
         <a class="button button_large" href="https://sales.theartofpostgresql.com/the-art-of-postgresql-book/">
           Buy the Book
         </a>

--- a/themes/taop/static/css/style.css
+++ b/themes/taop/static/css/style.css
@@ -428,6 +428,54 @@ body.course .welcome_slider ul li {
   margin: 0 30px 10px 0;
   min-width: 200px;
 }
+/* Full-bleed hero — book and index pages */
+.hero-slide {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+}
+.hero-content {
+  position: relative;
+  z-index: 1;
+  min-height: 100vh;
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 0 32px;
+  display: flex;
+  flex-flow: column nowrap;
+  justify-content: center;
+  align-items: center;
+}
+.hero-logo {
+  width: 100%;
+  max-width: 812px;
+  height: auto;
+  display: block;
+}
+.hero-cta {
+  margin: 40px 0 0;
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+@media (max-width: 640px) {
+  .hero-content {
+    padding: 0 20px;
+  }
+  .hero-cta {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 14px;
+    width: 100%;
+  }
+  .hero-cta .button {
+    text-align: center;
+    width: 100%;
+    box-sizing: border-box;
+  }
+}
+
 .welcome_slider .bx-pager {
   position: absolute;
   bottom: 57px;


### PR DESCRIPTION
## Problem

On narrow viewports (≤ 375 px) the hero logo (`welcome_logo.png`) overflowed the screen width because it only had `max-width: 812px` with no `width: 100%`, and the inline styles had no path for a media query.

## Solution

Extract the hero layout from inline styles into named CSS classes so a mobile breakpoint can apply:

| Class | Purpose |
|---|---|
| `.hero-slide` | Full-viewport container with `min-height: 100vh`, `overflow: hidden` |
| `.hero-content` | Flex column, centred, `max-width: 820px` |
| `.hero-logo` | `width: 100%; max-width: 812px` — scales down on narrow screens |
| `.hero-cta` | CTA button row |

**`@media (max-width: 640px)`** — buttons switch to `flex-direction: column`, full-width, removing the side-by-side layout that overflowed on small phones.

## Files changed

- `themes/taop/static/css/style.css` — new hero classes + mobile breakpoint
- `layouts/partials/index/caroussel.html` — use classes instead of inline styles
- `layouts/partials/book/caroussel.html` — same

## Tested

375 × 812 px (iPhone SE viewport): logo fits, buttons stack vertically.