### PR TITLE
feat: SQL and AI — new page, three YeSQL lessons, diagrams, book-updates polish

### DIFF
--- a/content/page/sql-and-ai.md
+++ b/content/page/sql-and-ai.md
@@ -1,0 +1,6 @@
++++
+title = "SQL and AI: Why You Still Need to Understand SQL"
+slug = "sql-and-ai"
+description = "AI generates queries. It cannot understand your database, design your schema, or catch a wrong JOIN. That is still a human job."
+layout = "sql-and-ai"
++++

--- a/content/yesql/sql-foundations/sql-and-ai-count.md
+++ b/content/yesql/sql-foundations/sql-and-ai-count.md
@@ -1,0 +1,150 @@
++++
+title = "COUNT(*) After a JOIN Counts Rows, Not Things"
+weight = 80
+summary = "After a JOIN, COUNT(*) counts the rows in the intermediate result — which is not the same as counting the distinct entities you care about. The wrong number is plausible, which makes it dangerous."
+tags = ["SQL", "COUNT", "JOIN", "AI", "Aggregation", "Common Mistakes"]
+lab_datasets = "f1db"
++++
+
+Ask an AI to count how many distinct races each nationality's drivers have participated in across F1 history, and there is a good chance it will write this:
+
+```sql
+select d.nationality,
+       count(*) as race_count
+  from f1db.drivers d
+  join f1db.results r  on r.driverid  = d.driverid
+  join f1db.races   ra on ra.raceid   = r.raceid
+ group by d.nationality
+ order by race_count desc
+ limit 8;
+```
+
+```
+ nationality │ race_count
+═════════════╪════════════
+ British     │       4136
+ Italian     │       3357
+ French      │       2739
+ German      │       2165
+ Brazilian   │       1942
+ American    │       1278
+ Finnish     │        947
+ Australian  │        709
+(8 rows)
+```
+
+The query ran. The numbers look reasonable — British drivers have been in F1 since the beginning, so a large number seems plausible. But the F1 championship has had fewer than 1,100 races in its entire history. No nationality can have participated in 4,136 races.
+
+The query is not counting races. It is counting rows in the join result.
+
+![Three-table join showing how COUNT(*) counts (driver, race) pairs instead of distinct races](/img/diagrams/fig-count-join-explosion.svg)
+
+### What COUNT(*) actually counts
+
+When you join `results` to `races`, each result row stays attached to its race row. A race with twenty drivers produces twenty joined rows — one per driver. `COUNT(*)` then counts those twenty rows, not one race.
+
+For British drivers, there are typically two to four British drivers on the grid in any given season. `COUNT(*)` adds one for each of them. Over seventy-plus years, that accumulates to 4,136 result rows — not 4,136 distinct races.
+
+The correct query uses `COUNT(DISTINCT raceid)`:
+
+```sql
+select d.nationality,
+       count(distinct ra.raceid) as race_count
+  from f1db.drivers d
+  join f1db.results r  on r.driverid = d.driverid
+  join f1db.races   ra on ra.raceid  = r.raceid
+ group by d.nationality
+ order by race_count desc
+ limit 8;
+```
+
+```
+ nationality │ race_count
+═════════════╪════════════
+ British     │        953
+ French      │        835
+ Italian     │        797
+ Brazilian   │        791
+ German      │        790
+ Finnish     │        616
+ Australian  │        606
+ Austrian    │        559
+(8 rows)
+```
+
+953 is the correct answer for British. There have been 953 championship races in which at least one British driver participated — not 4,136.
+
+The wrong result (4,136) was off by a factor of 4.3. The error was invisible because the number was plausible in isolation.
+
+### What COUNT(*) is actually doing
+
+SQL's `COUNT(*)` is straightforward: it counts the rows in the relation it operates on. After a join, that relation is the *Cartesian product filtered by the join conditions* — one row per matching pair. If you joined results to races, you have one row per (driver, race) pair. `COUNT(*)` counts pairs.
+
+To count distinct things after a join, name the thing:
+
+```sql
+count(distinct ra.raceid)    -- distinct races a driver appeared in
+count(distinct d.driverid)   -- distinct drivers who appeared in a race
+count(distinct r.constructorid) -- distinct constructors active in a season
+```
+
+The difference matters most when the join is one-to-many or many-to-many. In a strict one-to-one join, `COUNT(*)` and `COUNT(DISTINCT pk)` give the same answer — which is why AI-generated queries often pass superficial review.
+
+### The diagnostic question
+
+After any join, ask: *what does one row in this relation represent?*
+
+In `results JOIN races`, one row represents a (driver, race) pair.
+
+If the question is "how many races?", the answer is `COUNT(DISTINCT raceid)`, not `COUNT(*)`.
+
+If the question is "how many starts?", the answer is `COUNT(*)` — because that is exactly what you are counting.
+
+Many questions that sound like "how many X?" are actually "how many distinct X?", and AI tools default to `COUNT(*)` because it is simpler to write. Recognizing the join structure is the only way to know which one you need.
+
+### Making the overcounting visible
+
+The two numbers — 4,136 and 953 — are related by exactly the average number of British drivers per race. You can make that relationship explicit:
+
+```sql
+with per_race as (
+  select d.nationality,
+         ra.raceid,
+         count(*) as drivers_in_race
+    from f1db.drivers d
+    join f1db.results r  on r.driverid = d.driverid
+    join f1db.races   ra on ra.raceid  = r.raceid
+   group by d.nationality, ra.raceid
+)
+select nationality,
+       count(*)                                                                     as races,
+       round(avg(drivers_in_race), 1)                                              as avg,
+       round(percentile_cont(0.5) within group (order by drivers_in_race)::numeric, 1) as median,
+       round(percentile_cont(0.99) within group (order by drivers_in_race)::numeric, 1) as p99
+  from per_race
+ group by nationality
+ order by races desc
+ limit 10;
+```
+
+```
+ nationality │ races │ avg │ median │ p99
+═════════════╪═══════╪═════╪════════╪══════
+ British     │   953 │ 4.3 │    4.0 │ 12.5
+ French      │   835 │ 3.3 │    3.0 │  7.0
+ Italian     │   797 │ 4.2 │    3.0 │ 14.0
+ Brazilian   │   791 │ 2.5 │    2.0 │  4.0
+ German      │   790 │ 2.7 │    2.0 │  6.0
+ Finnish     │   616 │ 1.5 │    2.0 │  2.0
+ Australian  │   606 │ 1.2 │    1.0 │  2.0
+ Austrian    │   559 │ 1.2 │    1.0 │  3.0
+ American    │   469 │ 2.7 │    2.0 │ 34.0
+ Belgian     │   426 │ 1.3 │    1.0 │  3.0
+(10 rows)
+```
+
+British: 953 races × 4.3 average drivers per race = 4,136. That is exactly the number the first query returned. `COUNT(*)` was not wrong about anything — it correctly counted 4,136 (driver, race) rows. The mistake was treating that count as an answer to "how many races?"
+
+The p99 column tells an additional story. American drivers appear in 469 distinct races with a p99 of 34 drivers — a trace of the Indianapolis 500 era, when American fields were dominated by local entrants. Finnish drivers cluster tightly at median 2, p99 2: Finnish F1 participation was always a small, elite group. The shape of the distribution says something real about how each nationality has participated in the sport.
+
+`COUNT(DISTINCT raceid)` opens the door to this kind of analysis. `COUNT(*)` closes it.

--- a/content/yesql/sql-foundations/sql-and-ai-left-join.md
+++ b/content/yesql/sql-foundations/sql-and-ai-left-join.md
@@ -1,0 +1,103 @@
++++
+title = "The JOIN That Silently Loses Rows"
+weight = 70
+summary = "The most common AI SQL mistake: a LEFT JOIN paired with a WHERE clause that filters on the right-side table, silently turning an outer join into an inner join and dropping the rows you asked for."
+tags = ["SQL", "JOIN", "LEFT JOIN", "AI", "Common Mistakes"]
+lab_datasets = "f1db"
++++
+
+Ask an AI to *"show me all constructors and their 2017 points, including those with zero points"* and you will very likely get a query like this:
+
+```sql
+select c.name,
+       coalesce(sum(r.points), 0) as total_points
+  from f1db.constructors c
+  left join f1db.results r on r.constructorid = c.constructorid
+  left join f1db.races ra   on ra.raceid = r.raceid
+ where ra.year = 2017
+ group by c.name
+ order by total_points desc;
+```
+
+```
+     name     │ total_points
+══════════════╪══════════════
+ Mercedes     │          357
+ Ferrari      │          318
+ Red Bull     │          184
+ Force India  │          101
+ Williams     │           41
+ Toro Rosso   │           39
+ Haas F1 Team │           29
+ Renault      │           26
+ McLaren      │           11
+ Sauber       │            5
+(10 rows)
+```
+
+Ten rows. The query ran, returned numbers, and the numbers look correct. But you asked for *all* constructors — including historical ones that never raced in 2017. There are 208 constructors in the database. The query silently dropped 198 of them.
+
+### Why the LEFT JOIN did nothing
+
+A `LEFT JOIN` keeps every row from the left table, filling right-side columns with NULL when no match is found. The whole point is to preserve left-side rows that have no matching right-side rows.
+
+The `WHERE ra.year = 2017` clause then runs. For any constructor that had no 2017 entries, `ra.year` is NULL — and `NULL = 2017` evaluates to NULL, not false. A NULL predicate in `WHERE` is treated the same as false: the row is excluded.
+
+The outer join succeeded. The WHERE filter immediately undid it.
+
+This pattern is one of the most common mistakes in AI-generated SQL because it looks structurally correct: there are LEFT JOINs, there is a COALESCE for the zero case, the aggregation is right. The error is in the interaction between the join type and the filter placement.
+
+### The fix: filter before the join
+
+Move the year filter inside a subquery or a lateral join, so it runs *before* the outer join rather than after:
+
+```sql
+select c.name,
+       coalesce(sum(yr.points), 0) as total_points
+  from f1db.constructors c
+  left join (
+      select r.constructorid, r.points
+        from f1db.results r
+        join f1db.races ra on ra.raceid = r.raceid
+       where ra.year = 2017
+  ) yr on yr.constructorid = c.constructorid
+ group by c.name
+ order by total_points desc;
+```
+
+```
+           name            │ total_points
+═══════════════════════════╪══════════════
+ Mercedes                  │          357
+ Ferrari                   │          318
+ Red Bull                  │          184
+ Force India               │          101
+ Williams                  │           41
+ Toro Rosso                │           39
+ Haas F1 Team              │           29
+ Renault                   │           26
+ McLaren                   │           11
+ Sauber                    │            5
+ Maserati                  │            0
+ Embassy Hill              │            0
+ March                     │            0
+...
+(208 rows)
+```
+
+Now the subquery `yr` collects 2017 results only. The outer join then asks: "does this constructor appear in `yr`?" For the 198 constructors that never raced in 2017, the answer is no — and their `yr.points` column is NULL. `COALESCE(NULL, 0)` produces the zero you asked for.
+
+### The diagnostic question
+
+Whenever you see a `LEFT JOIN` in AI-generated code, check whether the `WHERE` clause references a column from the right-side table. If it does, and the condition does not explicitly allow NULLs (`IS NULL` or `IS NOT DISTINCT FROM`), the outer join is neutralized.
+
+```sql
+-- Outer join neutralized: ra.year filters out NULL rows from unmatched left-side rows
+left join f1db.races ra on ra.raceid = r.raceid
+where ra.year = 2017                             -- ← drops unmatched rows
+
+-- Outer join preserved: filter lives inside the join, not after it
+left join (... where ra.year = 2017) yr on ...   -- ← unmatched rows survive as NULLs
+```
+
+The instinct to develop: when you read a query and spot a `LEFT JOIN`, immediately ask what happens to the unmatched rows. Follow them through the `WHERE` clause. If any condition on a right-side column would evaluate to something other than true for a NULL row, the unmatched rows are gone — and the outer join was pointless. That reflex is what separates reading SQL from just looking at it.

--- a/content/yesql/sql-foundations/sql-and-ai-schema.md
+++ b/content/yesql/sql-foundations/sql-and-ai-schema.md
@@ -1,0 +1,128 @@
++++
+title = "The Schema Decision AI Cannot Make"
+weight = 90
+summary = "AI tools default to TEXT columns and application logic because they do not know what your database can express. Knowing PostgreSQL's range types, exclusion constraints, and generated columns changes what you ask for — and what you get."
+tags = ["SQL", "Schema Design", "Range Types", "Exclusion Constraints", "AI", "PostgreSQL"]
+lab_datasets = "f1db"
++++
+
+The most consequential SQL decisions happen before a single query is written.
+
+When you ask an AI to design a schema for storing driver career histories — which constructor each driver was with, and when — you will typically get something like this:
+
+```sql
+create table driver_contract (
+    id          serial      primary key,
+    driver_id   int         not null references drivers(driverid),
+    constructor text        not null,
+    start_year  int,
+    end_year    int
+);
+```
+
+This works in the sense that you can store data in it. It enforces nothing. Two rows could claim the same driver was at two different constructors in the same year. The overlap detection — if any — lives in your application code, where it will be quietly wrong when a concurrent transaction writes a conflicting row, or when someone imports data with a script that bypasses the checks.
+
+### What PostgreSQL can actually do here
+
+PostgreSQL has range types — `int4range`, `daterange`, `tstzrange` — and their multi-interval counterparts: `int4multirange`, `datemultirange`, `tstzmultirange`. A range stores a single start-to-end interval as one value with built-in operators for containment (`@>`), overlap (`&&`), adjacency (`-|-`), and more. A multirange stores *any number* of non-overlapping intervals as a single column value.
+
+That distinction matters here. Fernando Alonso drove for McLaren in 2007, then left, then returned from 2015 to 2017. With separate `start_year`/`end_year` columns you need two rows to represent his McLaren relationship. With `int4multirange` you need one:
+
+```
+active_years = '{[2007,2008), [2015,2018)}'
+```
+
+His two Renault stints (2003–2006, then 2008–2009 after his single McLaren year) collapse the same way.
+
+Paired with a GiST exclusion constraint, the database enforces non-overlap at write time — no trigger needed:
+
+```sql
+create table sandbox.driver_contract_range (
+    driver_id    int              not null,
+    constructor  text             not null,
+    active_years int4multirange   not null,
+    exclude using gist (driver_id with =, active_years with &&)
+);
+```
+
+The `EXCLUDE USING GIST` clause says: no two rows with the same `driver_id` may have *overlapping* `active_years` values. The `&&` operator is the range-overlap test; it works identically on multiranges.
+
+Populate it with real F1 career data:
+
+```sql
+insert into sandbox.driver_contract_range (driver_id, constructor, active_years) values
+    (1,  'McLaren',    '{[2007,2013)}'),
+    (1,  'Mercedes',   '{[2013,2018)}'),
+    (30, 'Jordan',     '{[1991,1992)}'),
+    (30, 'Benetton',   '{[1992,1996)}'),
+    (30, 'Ferrari',    '{[1996,2007)}'),
+    (30, 'Mercedes',   '{[2010,2013)}'),
+    (20, 'Toro Rosso', '{[2007,2009)}'),
+    (20, 'Red Bull',   '{[2009,2015)}'),
+    (20, 'Ferrari',    '{[2015,2018)}'),
+    (4,  'Minardi',    '{[2001,2002)}'),
+    (4,  'Renault',    '{[2003,2007), [2008,2010)}'),
+    (4,  'McLaren',    '{[2007,2008), [2015,2018)}'),
+    (4,  'Ferrari',    '{[2010,2015)}');
+```
+
+The `{...}` wrapper is the multirange literal syntax. A value like `'{[2003,2007), [2008,2010)}'` holds two subranges; a value like `'{[2007,2013)}'` holds one. Both are valid `int4multirange` values. Each subrange uses the standard half-open notation: inclusive on the left, exclusive on the right.
+
+![Fernando Alonso career timeline showing multirange active_years values and @> containment query at 2010](/img/diagrams/fig-multirange-career.svg)
+
+### Point-in-time queries with a single operator
+
+The `@>` (containment) operator answers "does this range contain this value?" — and it works across all subranges of a multirange in a single check:
+
+```sql
+select d.forename || ' ' || d.surname as driver,
+       c.constructor
+  from sandbox.driver_contract_range c
+  join f1db.drivers d on d.driverid = c.driver_id
+ where c.active_years @> 2010
+ order by driver;
+```
+
+```
+       driver       │ constructor
+════════════════════╪═════════════
+ Fernando Alonso    │ Ferrari
+ Lewis Hamilton     │ McLaren
+ Michael Schumacher │ Mercedes
+ Sebastian Vettel   │ Red Bull
+(4 rows)
+```
+
+The 2010 season: Alonso starting his Ferrari era, Hamilton at McLaren, Schumacher coming out of retirement at Mercedes, Vettel beginning his dominant Red Bull years. The query needs no date arithmetic, no `BETWEEN`, no `start_year <= 2010 AND (end_year IS NULL OR end_year > 2010)` gymnastics. One operator, one check per column value regardless of how many subranges it contains.
+
+### The constraint fires at write time
+
+Now try inserting a row that overlaps with Hamilton's existing McLaren stint:
+
+```sql
+insert into sandbox.driver_contract_range (driver_id, constructor, active_years)
+values (1, 'Red Bull', '{[2011,2014)}');
+```
+
+```
+ERROR:  conflicting key value violates exclusion constraint
+        "driver_contract_range_driver_id_active_years_excl"
+DETAIL: Key (driver_id, active_years)=(1, {[2011,2014)}) conflicts with
+        existing key (driver_id, active_years)=(1, {[2007,2013)}).
+```
+
+The database rejected it. No application logic ran. No trigger was needed. The constraint checked the incoming multirange against every existing range for `driver_id = 1` using the GiST index and refused the write the moment it found an overlap.
+
+The TEXT-column schema with separate `start_year` and `end_year` columns cannot express this constraint at all. You cannot write `EXCLUDE USING GIST` on two integer columns — the operator class does not exist for plain integers paired with equality. You need a range type, and once you have one, the step to multirange costs nothing.
+
+### Why this matters in the AI context
+
+An AI given the prompt "design a table to store which constructor each driver was with and when" will produce the TEXT/integer version. It does not know that `int4multirange` exists. It does not know that `EXCLUDE USING GIST` can enforce non-overlap at the database level. It will not volunteer these options unprompted.
+
+If you know they exist, you ask a different question:
+
+> *"Design a table to store F1 driver constructor contracts, using int4multirange for the active periods and an exclusion constraint to prevent a driver from appearing at two constructors in the same season."*
+
+That prompt produces the multirange schema. The AI can write the SQL once you tell it what to use. The knowledge of *what to ask for* — of what PostgreSQL can express — is yours to supply.
+
+This is the structural reason why SQL literacy matters in the AI era. The database's expressive range — range types, exclusion constraints, generated columns, `MERGE`, row-level security, partial indexes — is not visible to an AI that has not been told to reach for it. You know your requirements. You now need to know what the database can do with them.

--- a/layouts/book/book-updates.html
+++ b/layouts/book/book-updates.html
@@ -22,8 +22,11 @@
     .bku-eyebrow { font: 700 11px/1 'Lato'; letter-spacing: 3px; text-transform: uppercase; color: #60b2d3; margin: 0 0 16px; }
     .bku-page h1 { font: 300 2.6rem/1.1 'Lato'; color: #372649; margin: 0 0 12px; }
     .bku-lede { font: 300 1.15rem/1.65 'Lato'; color: #67527a; margin: 0 0 56px; max-width: 640px; }
+    .bku-aside { display: flex; align-items: center; gap: 16px; font: 300 1.0rem/1.6 'Lato'; color: #67527a; margin: -36px 0 40px; max-width: 640px; }
+    .bku-aside i { flex-shrink: 0; font-size: 2.9rem; color: #60b2d3; line-height: 1; }
+    .bku-aside a { font-weight: 700; color: #372649; }
     .bku-free-banner { background: #372649; color: #fff; border-radius: 8px; padding: 20px 28px; margin-bottom: 56px; display: flex; align-items: center; gap: 16px; }
-    .bku-free-banner i { font-size: 1.4rem; color: #60b2d3; flex-shrink: 0; }
+    .bku-free-banner i { font-size: 3rem; color: #60b2d3; flex-shrink: 0; line-height: 1; }
     .bku-free-banner p { margin: 0; font: 400 0.95rem/1.5 'Lato'; }
     .bku-free-banner a { color: #60b2d3; }
     .bku-section { margin-bottom: 56px; }
@@ -53,6 +56,7 @@
     .bku-cta h3 { font: 300 1.5rem/1.2 'Lato'; color: #372649; margin: 0 0 10px; }
     .bku-cta p { font: 300 0.95rem/1.6 'Lato'; color: #67527a; margin: 0 0 24px; }
     .bku-cta-buttons { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+    .bku-gallery-label { font: 700 11px/1 'Lato'; letter-spacing: 2px; text-transform: uppercase; color: #9e8fb0; margin: 0 0 14px; }
     .bku-gallery { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 56px; }
     .bku-gallery-fig { margin: 0; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 12px rgba(55,38,73,0.10); background: #fff; }
     .bku-gallery-img-box { height: 210px; display: flex; align-items: center; justify-content: center; padding: 14px; background: #fff; overflow: hidden; }
@@ -82,6 +86,11 @@
     adds an entirely new chapter on vector search, introduces 56 new figures, and
     ships with a fully integrated companion lab.
   </p>
+  <p class="bku-aside">
+    <span>Wondering whether SQL still matters now that AI can generate queries?</span>
+    <i class="fa-solid fa-robot"></i>
+    <a href="/sql-and-ai/">Here's why it matters more than ever. →</a>
+  </p>
 
   <div class="bku-free-banner">
     <i class="fa-solid fa-gift"></i>
@@ -92,6 +101,8 @@
       Questions? Email <a href="mailto:dim@tapoueh.org">dim@tapoueh.org</a> with your order email.
     </p>
   </div>
+
+  <p class="bku-gallery-label">A selection of the 56 new figures in this edition</p>
 
   <div class="bku-gallery">
     <figure class="bku-gallery-fig">

--- a/layouts/page/sql-and-ai.html
+++ b/layouts/page/sql-and-ai.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>SQL and AI: Why You Still Need to Understand SQL | The Art of PostgreSQL</title>
+  <meta name="description" content="AI tools can generate queries. They cannot understand your database, architect your schema, or catch what goes silently wrong. That is still a human job.">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:site" content="@tapoueh" />
+  <meta property="og:url" content="https://theartofpostgresql.com/sql-and-ai/" />
+  <meta property="og:title" content="SQL and AI: Why You Still Need to Understand SQL" />
+  <meta property="og:description" content="AI generates queries. It cannot understand your database, design your schema, or catch a wrong JOIN that runs silently. That is still a human job." />
+  <meta property="og:image" content="https://theartofpostgresql.com/images/hardcover-mockup.jpg" />
+  <link href="/favicon.ico" rel="icon" type="image/x-icon">
+  <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+  <link rel="stylesheet" href="/css/style.css">
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/bxslider/4.2.12/jquery.bxslider.min.js"></script>
+  <script src="/js/custom.js"></script>
+  <style>
+    .sai-page { max-width: 780px; margin: 0 auto; padding: 120px 24px 120px; }
+    .sai-eyebrow { font: 700 11px/1 'Lato'; letter-spacing: 3px; text-transform: uppercase; color: #60b2d3; margin: 0 0 20px; display: flex; align-items: center; gap: 9px; }
+    .sai-eyebrow i { font-size: 0.95rem; }
+    .sai-page h1 { font: 300 2.6rem/1.1 'Lato'; color: #372649; margin: 0 0 20px; }
+    .sai-lede { font: 300 1.18rem/1.72 'Lato'; color: #67527a; margin: 0 0 60px; }
+    .sai-lede code { font-size: 0.88em; background: #ede8f2; padding: 1px 6px; border-radius: 3px; color: #372649; }
+
+    .sai-intro-wrap { display: flex; gap: 52px; align-items: flex-start; margin-bottom: 60px; }
+    .sai-intro-text { flex: 1 1 0; min-width: 0; }
+    .sai-intro-cover { flex: 0 0 auto; width: 188px; padding-top: 6px; }
+    .sai-intro-cover img { width: 100%; height: auto; display: block; border-radius: 3px; box-shadow: 0 10px 36px rgba(55,38,73,0.20), 0 2px 8px rgba(55,38,73,0.10); }
+
+    .sai-section { margin-bottom: 60px; }
+    .sai-section-header { display: flex; align-items: flex-start; gap: 18px; margin-bottom: 20px; }
+    .sai-icon { width: 44px; height: 44px; border-radius: 50%; background: #ede8f2; display: flex; align-items: center; justify-content: center; flex-shrink: 0; margin-top: 2px; }
+    .sai-icon i { color: #372649; font-size: 1.1rem; }
+    .sai-section h2 { font: 700 1.25rem/1.25 'Lato'; color: #372649; margin: 0 0 4px; }
+    .sai-section .sai-sub { font: 300 0.95rem/1.45 'Lato'; color: #67527a; margin: 0; }
+    .sai-section p { font: 300 1.06rem/1.75 'Lato'; color: #444; margin: 0 0 16px; }
+    .sai-section p:last-child { margin-bottom: 0; }
+    .sai-section code { font-size: 0.88em; background: #f0ecf5; padding: 1px 5px; border-radius: 3px; color: #372649; }
+    .sai-divider { border: none; border-top: 2px solid #ede8f2; margin: 0 0 60px; }
+    .sai-further { font: 400 0.95rem/1.65 'Lato'; color: #372649; padding: 0 40px; margin: 20px 0 0; }
+    .sai-further a { color: #372649; text-decoration: underline; text-decoration-color: #60b2d3; text-underline-offset: 3px; }
+    .sai-further a:hover { color: #60b2d3; }
+
+    .sai-pullquote { position: relative; margin: 0 0 60px; padding: 6px 32px 20px 64px; background: #f8f7f9; border-radius: 8px; }
+    .sai-pullquote::before { content: '\201C'; position: absolute; top: -4px; left: 20px; font: 700 5rem/1 Georgia, serif; color: #60b2d3; line-height: 1; }
+    .sai-pullquote p { font: 300 1.05rem/1.65 'Lato'; color: #372649; margin: 0; text-indent: 0.6em; }
+    .sai-pullquote cite { display: block; margin-top: 10px; font: 400 0.83rem/1 'Lato'; color: #67527a; font-style: normal; }
+
+    .sai-stat-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; margin-bottom: 60px; }
+    .sai-stat { background: #fff; border: 1px solid #e4dded; border-radius: 10px; padding: 28px 22px 20px; display: flex; flex-direction: column; align-items: center; text-align: center; }
+    .sai-stat-icon { width: 46px; height: 46px; border-radius: 50%; background: #ede8f2; display: flex; align-items: center; justify-content: center; margin-bottom: 18px; }
+    .sai-stat-icon i { color: #372649; font-size: 1.1rem; }
+    .sai-stat-num { font: 700 2.4rem/1 'Lato'; color: #372649; display: block; margin-bottom: 12px; letter-spacing: -0.02em; }
+    .sai-stat-label { font: 300 0.88rem/1.5 'Lato'; color: #67527a; flex: 1; }
+    .sai-stat-source { display: block; margin-top: 16px; padding-top: 14px; border-top: 1px solid #ede8f2; width: 100%; font: 400 0.75rem/1 'Lato'; color: #9e8fb0; text-decoration: none; letter-spacing: 0.01em; }
+    .sai-stat-source:hover { color: #372649; }
+
+    .sai-cta { background: #372649; border-radius: 8px; padding: 48px 40px; text-align: center; margin-top: 60px; }
+    .sai-cta h3 { font: 300 1.6rem/1.2 'Lato'; color: #fff; margin: 0 0 12px; }
+    .sai-cta p { font: 300 0.97rem/1.65 'Lato'; color: #b8a8cc; margin: 0 0 28px; max-width: 520px; margin-left: auto; margin-right: auto; }
+    .sai-cta-buttons { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; }
+    .sai-cta .button.button_purple,
+    .sai-cta .button.button_purple:visited { background: #60b2d3; border-color: #60b2d3; }
+    .sai-cta .button.button_purple:hover   { background: #372649; border-color: #60b2d3; }
+
+    @media (max-width: 640px) {
+      .sai-page { padding: 48px 16px 80px; }
+      .sai-page h1 { font-size: 1.9rem; }
+      .sai-intro-wrap { flex-direction: column-reverse; gap: 24px; }
+      .sai-intro-cover { width: 140px; }
+      .sai-stat-row { grid-template-columns: 1fr; gap: 12px; }
+      .sai-pullquote { padding: 14px 18px; }
+      .sai-cta { padding: 36px 20px; }
+    }
+  </style>
+</head>
+<body class="page">
+
+{{ partial "header.html" . }}
+
+<div class="sai-page">
+
+  <div class="sai-intro-wrap">
+    <div class="sai-intro-text">
+      <p class="sai-eyebrow"><i class="fa-solid fa-robot"></i> The Art of PostgreSQL</p>
+      <h1>You Still Need SQL —<br>Even When AI Writes the Queries</h1>
+      <p class="sai-lede">
+        AI tools can generate a query from a plain-English description. What they
+        cannot do is understand your database, design your schema, or catch a
+        wrong <code>JOIN</code> that runs without error but returns subtly incorrect
+        numbers. That is still a human job — and it starts with knowing SQL.
+      </p>
+    </div>
+    <div class="sai-intro-cover">
+      <img src="/images/hardcover-mockup.jpg" alt="The Art of PostgreSQL — hardcover">
+    </div>
+  </div>
+
+  <!-- ── Section 1 ── -->
+  <div class="sai-section">
+    <div class="sai-section-header">
+      <div class="sai-icon"><i class="fa-solid fa-bullseye"></i></div>
+      <div>
+        <h2>AI writes queries. You still decide what to ask.</h2>
+        <p class="sai-sub">The question is no longer "can I write this query?" — it is "do I know what query to write?"</p>
+      </div>
+    </div>
+    <p>
+      The most powerful use of an AI coding assistant is not typing
+      <em>write me a SQL query</em>. It is knowing exactly what the query should
+      do — which join type, which aggregation, whether a window function or a
+      subquery fits the logic — and using the assistant to get there faster.
+    </p>
+    <p>
+      That knowledge is what separates a developer who gives the AI a precise
+      prompt and reviews the result confidently from one who pastes the output
+      into production and hopes. The first person knows SQL. The second is
+      guessing.
+    </p>
+  </div>
+
+  <hr class="sai-divider">
+
+  <!-- ── Section 2 ── -->
+  <div class="sai-section">
+    <div class="sai-section-header">
+      <div class="sai-icon"><i class="fa-solid fa-database"></i></div>
+      <div>
+        <h2>Your database is not in the training data.</h2>
+        <p class="sai-sub">Production schemas have undocumented tables, cryptic column names, and implicit business rules.</p>
+      </div>
+    </div>
+    <p>
+      Text-to-SQL tools perform well on clean, well-documented schemas with
+      roughly twenty tables and explicit foreign keys. On the
+      <a href="https://beehive-advisors.com/blog/bird-bench" target="_blank" rel="noopener">BIRD benchmark</a>
+      — which was designed specifically for real-world database conditions —
+      accuracy drops to around <strong>64% on complex queries</strong>, even
+      with ideal, well-documented inputs. Real production databases are
+      different: columns named <code>flg_acct_tp</code>, tables that were
+      deprecated three years ago but are still joined in a dozen queries,
+      foreign key relationships that were never declared.
+    </p>
+    <p>
+      The AI does not know your schema is broken. It does not know that
+      <code>orders.status = 3</code> means "shipped" in your system. You do —
+      or you should — and that understanding comes from knowing what a
+      relational model is supposed to look like and recognizing when yours
+      diverges from it.
+    </p>
+  </div>
+
+  <div class="sai-pullquote">
+    <p>"People doing mission-critical, secure, accurate database development on
+    large existing databases will still struggle in 2026 due to undocumented
+    databases and bad tooling."</p>
+    <cite>— <a href="https://www.brentozar.com/archive/2026/01/database-development-with-ai-in-2026/" target="_blank" rel="noopener">Brent Ozar, January 2026</a></cite>
+  </div>
+
+  <!-- ── Section 3 ── -->
+  <div class="sai-section">
+    <div class="sai-section-header">
+      <div class="sai-icon"><i class="fa-solid fa-triangle-exclamation"></i></div>
+      <div>
+        <h2>Wrong SQL runs. You need to catch it.</h2>
+        <p class="sai-sub">A bad <code>LEFT JOIN</code> returns numbers. They just aren't the right ones.</p>
+      </div>
+    </div>
+    <p>
+      SQL errors fall into two categories: syntax errors, which the database
+      rejects immediately, and logic errors, which the database happily
+      executes and returns plausible-looking numbers that are quietly wrong.
+    </p>
+    <p>
+      Using a <code>LEFT JOIN</code> where an <code>INNER JOIN</code> is
+      correct inflates aggregates with <code>NULL</code>-padded rows.
+      Grouping at the wrong level double-counts. Filtering after a join
+      instead of before changes the result set. None of these produce an
+      error. They produce a wrong answer that looks right until someone
+      compares it against another source.
+    </p>
+    <p>
+      AI-generated SQL is only useful if you can read it, evaluate it, and
+      catch what is wrong. That skill is exactly what SQL literacy gives you —
+      and it matters more in the AI era, not less.
+    </p>
+    <p class="sai-further">
+      We cover both mistakes in detail, with actual SQL run against a real database:
+      <a href="/yesql/sql-foundations/sql-and-ai-left-join/">a LEFT JOIN that silently drops 198 rows when paired with a WHERE on the right-side table</a>,
+      and <a href="/yesql/sql-foundations/sql-and-ai-count/">a COUNT(*) that overcounts by a factor of four because the join multiplies rows</a>.
+    </p>
+  </div>
+
+  <hr class="sai-divider">
+
+  <!-- ── Section 4 ── -->
+  <div class="sai-section">
+    <div class="sai-section-header">
+      <div class="sai-icon"><i class="fa-solid fa-layer-group"></i></div>
+      <div>
+        <h2>Schema design is not a query problem.</h2>
+        <p class="sai-sub">The most consequential SQL decisions happen before a single SELECT is written.</p>
+      </div>
+    </div>
+    <p>
+      How you model a many-to-many relationship, whether a timeline should use
+      a <code>tstzrange</code> or two timestamp columns, when a generated
+      stored column is the right answer versus a view — these are design
+      decisions that determine which queries are fast, which constraints
+      enforce correctness at write time, and which ones require a trigger or
+      an application workaround to work around a brittle schema.
+    </p>
+    <p>
+      An AI cannot make these choices for you because the choices depend on
+      your specific access patterns, your team's operational practices, and
+      your tolerance for schema migration complexity. The only way to make
+      them well is to understand what PostgreSQL can actually express — range
+      types, exclusion constraints, partial indexes, generated columns,
+      <code>MERGE</code>, row-level security — so you know what options exist
+      before you commit to a design.
+    </p>
+    <p>
+      That is the argument at the center of this book: knowing what is possible
+      lets you make better design decisions than any tool that only looks at the
+      query surface.
+    </p>
+    <p class="sai-further">
+      We work through a concrete example with actual SQL:
+      <a href="/yesql/sql-foundations/sql-and-ai-schema/">the schema decision AI cannot make</a>
+      — how knowing PostgreSQL has <code>int4range</code> and exclusion constraints changes
+      what you ask for, and what you get back.
+    </p>
+  </div>
+
+  <!-- ── Stats ── -->
+  <div class="sai-stat-row">
+    <div class="sai-stat">
+      <div class="sai-stat-icon"><i class="fa-solid fa-robot"></i></div>
+      <span class="sai-stat-num">64%</span>
+      <span class="sai-stat-label">Accuracy on complex queries even with clean, well-documented schemas</span>
+      <a class="sai-stat-source" href="https://beehive-advisors.com/blog/bird-bench" target="_blank" rel="noopener">BIRD benchmark — real-world database conditions ↗</a>
+    </div>
+    <div class="sai-stat">
+      <div class="sai-stat-icon"><i class="fa-solid fa-briefcase"></i></div>
+      <span class="sai-stat-num">65–75%</span>
+      <span class="sai-stat-label">Of data job postings require SQL — more than Python or any ML framework</span>
+      <a class="sai-stat-source" href="https://lightcast.io/resources/blog/what-job-postings-say-about-demand-for-sql" target="_blank" rel="noopener">Lightcast — job postings analysis ↗</a>
+    </div>
+    <div class="sai-stat">
+      <div class="sai-stat-icon"><i class="fa-solid fa-code-branch"></i></div>
+      <span class="sai-stat-num">7</span>
+      <span class="sai-stat-label">Major PostgreSQL releases since the first edition, each adding new SQL capability</span>
+      <a class="sai-stat-source" href="https://www.postgresql.org/support/versioning/" target="_blank" rel="noopener">PostgreSQL versioning policy ↗</a>
+    </div>
+  </div>
+
+  <!-- ── Section 5 ── -->
+  <div class="sai-section">
+    <div class="sai-section-header">
+      <div class="sai-icon"><i class="fa-solid fa-chart-line"></i></div>
+      <div>
+        <h2>The market has not moved on from SQL.</h2>
+        <p class="sai-sub">Demand for SQL expertise is higher in 2026 than it was in 2019 when the first edition was published.</p>
+      </div>
+    </div>
+    <p>
+      SQL appears in 65–75% of data-related job descriptions — more than
+      Python, R, or any specific machine learning framework. The language is
+      standardized, stable, and supported by every relational database. AI
+      tools generate it, which means every data-adjacent role now assumes you
+      can read it and verify it, even if you no longer type every character by
+      hand.
+    </p>
+    <p>
+      PostgreSQL in particular has never been more relevant. Seven major
+      versions since 2019 have added window frame modes, multi-ranges,
+      <code>MERGE</code>, <code>RETURNING OLD / NEW</code>, <code>JSON_TABLE</code>,
+      virtual generated columns, and <code>uuidv7()</code> — none of which an AI
+      will reach for if it does not know you need them.
+    </p>
+  </div>
+
+  <!-- ── CTA ── -->
+  <div class="sai-cta">
+    <h3>The Art of PostgreSQL, Second Edition</h3>
+    <p>
+      A book for developers who want to understand SQL deeply enough to
+      design better schemas, write correct queries, and know what to ask —
+      with or without an AI in the loop.
+    </p>
+    <div class="sai-cta-buttons">
+      <a href="https://sales.theartofpostgresql.com/the-art-of-postgresql-book/"
+         class="button button_purple button_large">Get the Book — $89</a>
+      <a href="/book/updates/" class="button button_outline button_large"
+         style="color:#fff; border-color:#6b4e8c;">See What's New in 2026</a>
+    </div>
+  </div>
+
+</div>
+
+{{ partial "footer.html" . }}
+
+</body>
+</html>

--- a/static/img/diagrams/fig-count-join-explosion.svg
+++ b/static/img/diagrams/fig-count-join-explosion.svg
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 294"
+     role="img" aria-label="JOIN explosion: drivers JOIN results JOIN races produces one row per (driver, race) pair; COUNT(*) = 4136 vs COUNT(DISTINCT raceid) = 953">
+  <defs>
+    <marker id="cj-a" markerWidth="7" markerHeight="5" refX="6" refY="2.5" orient="auto">
+      <polygon points="0 0,7 2.5,0 5" fill="#9e8fb0"/>
+    </marker>
+    <marker id="cj-d" markerWidth="7" markerHeight="5" refX="6" refY="2.5" orient="auto">
+      <polygon points="0 0,7 2.5,0 5" fill="#c5bbcf"/>
+    </marker>
+  </defs>
+
+  <!-- ── f1db.drivers ── -->
+  <rect x="8"  y="10" width="162" height="120" rx="3" fill="#f8f7f9" stroke="#c5bbcf" stroke-width="1"/>
+  <path d="M11,10 A3,3 0 0,0 8,13 L8,36 L170,36 L170,13 A3,3 0 0,0 167,10 Z" fill="#372649"/>
+  <text x="89"  y="28" text-anchor="middle" fill="white"   font-size="11" font-family="ui-sans-serif,sans-serif" font-weight="bold">f1db.drivers</text>
+
+  <text x="18" y="53"  fill="#372649" font-size="10" font-family="ui-monospace,monospace">driverid</text>
+  <rect x="132" y="42" width="22" height="13" rx="2" fill="#60b2d3"/>
+  <text x="143" y="52" text-anchor="middle" fill="white" font-size="7" font-family="ui-sans-serif,sans-serif" font-weight="bold">PK</text>
+
+  <text x="18" y="71"  fill="#888" font-size="10" font-family="ui-monospace,monospace">nationality</text>
+  <text x="18" y="89"  fill="#888" font-size="10" font-family="ui-monospace,monospace">forename</text>
+  <text x="18" y="107" fill="#888" font-size="10" font-family="ui-monospace,monospace">surname</text>
+
+  <text x="89" y="144" text-anchor="middle" fill="#b8a8cc" font-size="9" font-family="ui-sans-serif,sans-serif">~ 850 rows</text>
+
+  <!-- ── f1db.results (center, highlighted) ── -->
+  <rect x="228" y="10" width="188" height="138" rx="3" fill="#ede8f2" stroke="#8b6fb0" stroke-width="1.5"/>
+  <path d="M231,10 A3,3 0 0,0 228,13 L228,36 L416,36 L416,13 A3,3 0 0,0 413,10 Z" fill="#372649"/>
+  <text x="322" y="28" text-anchor="middle" fill="white"   font-size="11" font-family="ui-sans-serif,sans-serif" font-weight="bold">f1db.results</text>
+
+  <text x="238" y="53"  fill="#372649" font-size="10" font-family="ui-monospace,monospace">resultid</text>
+  <rect x="350" y="42" width="22" height="13" rx="2" fill="#60b2d3"/>
+  <text x="361" y="52" text-anchor="middle" fill="white" font-size="7" font-family="ui-sans-serif,sans-serif" font-weight="bold">PK</text>
+
+  <text x="238" y="71"  fill="#372649" font-size="10" font-family="ui-monospace,monospace">driverid</text>
+  <rect x="350" y="60" width="22" height="13" rx="2" fill="#9e8fb0"/>
+  <text x="361" y="70" text-anchor="middle" fill="white" font-size="7" font-family="ui-sans-serif,sans-serif" font-weight="bold">FK</text>
+
+  <text x="238" y="89"  fill="#372649" font-size="10" font-family="ui-monospace,monospace">raceid</text>
+  <rect x="350" y="78" width="22" height="13" rx="2" fill="#9e8fb0"/>
+  <text x="361" y="88" text-anchor="middle" fill="white" font-size="7" font-family="ui-sans-serif,sans-serif" font-weight="bold">FK</text>
+
+  <text x="238" y="107" fill="#888" font-size="10" font-family="ui-monospace,monospace">constructorid</text>
+  <text x="238" y="125" fill="#888" font-size="10" font-family="ui-monospace,monospace">points</text>
+
+  <text x="322" y="162" text-anchor="middle" fill="#7c5c9e" font-size="9" font-family="ui-sans-serif,sans-serif">~ 23,000 rows</text>
+
+  <!-- ── f1db.races ── -->
+  <rect x="468" y="10" width="156" height="120" rx="3" fill="#f8f7f9" stroke="#c5bbcf" stroke-width="1"/>
+  <path d="M471,10 A3,3 0 0,0 468,13 L468,36 L624,36 L624,13 A3,3 0 0,0 621,10 Z" fill="#372649"/>
+  <text x="546" y="28" text-anchor="middle" fill="white"   font-size="11" font-family="ui-sans-serif,sans-serif" font-weight="bold">f1db.races</text>
+
+  <text x="478" y="53"  fill="#372649" font-size="10" font-family="ui-monospace,monospace">raceid</text>
+  <rect x="574" y="42" width="22" height="13" rx="2" fill="#60b2d3"/>
+  <text x="585" y="52" text-anchor="middle" fill="white" font-size="7" font-family="ui-sans-serif,sans-serif" font-weight="bold">PK</text>
+
+  <text x="478" y="71"  fill="#888" font-size="10" font-family="ui-monospace,monospace">year</text>
+  <text x="478" y="89"  fill="#888" font-size="10" font-family="ui-monospace,monospace">name</text>
+  <text x="478" y="107" fill="#888" font-size="10" font-family="ui-monospace,monospace">date</text>
+
+  <text x="546" y="144" text-anchor="middle" fill="#b8a8cc" font-size="9" font-family="ui-sans-serif,sans-serif">~ 976 rows</text>
+
+  <!-- ── Join arrow: drivers → results (ON driverid, 1:N) ── -->
+  <line x1="170" y1="67" x2="226" y2="68" stroke="#9e8fb0" stroke-width="1.5" marker-end="url(#cj-a)"/>
+  <text x="172" y="61" fill="#9e8fb0" font-size="9" font-family="ui-sans-serif,sans-serif">1</text>
+  <text x="208" y="61" fill="#9e8fb0" font-size="9" font-family="ui-sans-serif,sans-serif">N</text>
+  <text x="177" y="77" fill="#c5bbcf" font-size="7.5" font-family="ui-monospace,monospace">ON driverid</text>
+
+  <!-- ── Join arrow: races → results (ON raceid, 1:N) ── -->
+  <line x1="468" y1="50" x2="418" y2="86" stroke="#9e8fb0" stroke-width="1.5" marker-end="url(#cj-a)"/>
+  <text x="453" y="47" fill="#9e8fb0" font-size="9" font-family="ui-sans-serif,sans-serif">1</text>
+  <text x="420" y="98" fill="#9e8fb0" font-size="9" font-family="ui-sans-serif,sans-serif">N</text>
+  <text x="421" y="66" fill="#c5bbcf" font-size="7.5" font-family="ui-monospace,monospace">ON raceid</text>
+
+  <!-- ── Arrow down from results to join-result box ── -->
+  <line x1="322" y1="163" x2="322" y2="177" stroke="#c5bbcf" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#cj-d)"/>
+
+  <!-- ── Join result box ── -->
+  <rect x="8" y="178" width="638" height="108" rx="5" fill="#f8f7f9" stroke="#c5bbcf" stroke-width="1"/>
+
+  <text x="322" y="196" text-anchor="middle" fill="#372649" font-size="10" font-family="ui-sans-serif,sans-serif" font-weight="bold">join result — one row per (driver, race) pair</text>
+
+  <!-- vertical divider -->
+  <line x1="323" y1="202" x2="323" y2="278" stroke="#e4dded" stroke-width="1"/>
+
+  <!-- left: COUNT(*) -->
+  <text x="163" y="217" text-anchor="middle" fill="#555" font-size="9.5" font-family="ui-monospace,monospace">COUNT(*)</text>
+  <text x="163" y="232" text-anchor="middle" fill="#999" font-size="8.5" font-family="ui-sans-serif,sans-serif">counts every (driver, race) pair</text>
+  <text x="163" y="260" text-anchor="middle" fill="#b45309" font-size="28" font-family="ui-sans-serif,sans-serif" font-weight="bold">4,136</text>
+  <text x="163" y="275" text-anchor="middle" fill="#b45309" font-size="9"  font-family="ui-sans-serif,sans-serif">wrong for "how many races?"</text>
+
+  <!-- right: COUNT(DISTINCT raceid) -->
+  <text x="483" y="217" text-anchor="middle" fill="#555" font-size="9.5" font-family="ui-monospace,monospace">COUNT(DISTINCT ra.raceid)</text>
+  <text x="483" y="232" text-anchor="middle" fill="#999" font-size="8.5" font-family="ui-sans-serif,sans-serif">deduplicates before counting</text>
+  <text x="483" y="260" text-anchor="middle" fill="#256a40" font-size="28" font-family="ui-sans-serif,sans-serif" font-weight="bold">953</text>
+  <text x="483" y="275" text-anchor="middle" fill="#256a40" font-size="9"  font-family="ui-sans-serif,sans-serif">distinct races with British drivers</text>
+</svg>

--- a/static/img/diagrams/fig-multirange-career.svg
+++ b/static/img/diagrams/fig-multirange-career.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200"
+     role="img" aria-label="Fernando Alonso career timeline: multirange active_years column showing non-contiguous stints at Renault and McLaren; vertical dashed line at 2010 shows @> containment query returning Ferrari">
+
+  <!-- x(year) = 55 + (year − 2001) × 38.82 ; 2001→55, 2007→288, 2008→327, 2010→404, 2015→599, 2018→715 -->
+
+  <!-- ── title ── -->
+  <text x="384" y="18" text-anchor="middle"
+        fill="#372649" font-size="10.5" font-family="ui-sans-serif,sans-serif" font-weight="bold">
+    Fernando Alonso — active_years (driverid = 4)
+  </text>
+
+  <!-- ── @> 2010 dashed vertical line (full height) ── -->
+  <line x1="404" y1="24" x2="404" y2="188" stroke="#372649" stroke-width="1.5" stroke-dasharray="6,4"/>
+
+  <!-- ── Career timeline bars (y=30..58) ── -->
+
+  <!-- Minardi [2001,2002) -->
+  <rect x="55"  y="30" width="39"  height="28" rx="2" fill="#c5bbcf"/>
+  <text x="74"  y="49" text-anchor="middle" fill="#555" font-size="7.5" font-family="ui-sans-serif,sans-serif">Minardi</text>
+
+  <!-- Renault [2003,2007) -->
+  <rect x="133" y="30" width="155" height="28" rx="2" fill="#60b2d3"/>
+  <text x="210" y="49" text-anchor="middle" fill="white" font-size="9"   font-family="ui-sans-serif,sans-serif">Renault</text>
+
+  <!-- McLaren [2007,2008) -->
+  <rect x="288" y="30" width="39"  height="28" rx="2" fill="#7c5c9e"/>
+  <text x="307" y="49" text-anchor="middle" fill="white" font-size="7"   font-family="ui-sans-serif,sans-serif">McLaren</text>
+
+  <!-- Renault [2008,2010) -->
+  <rect x="327" y="30" width="77"  height="28" rx="2" fill="#60b2d3"/>
+  <text x="365" y="49" text-anchor="middle" fill="white" font-size="9"   font-family="ui-sans-serif,sans-serif">Renault</text>
+
+  <!-- Ferrari [2010,2015) -->
+  <rect x="404" y="30" width="195" height="28" rx="2" fill="#bf4040"/>
+  <text x="501" y="49" text-anchor="middle" fill="white" font-size="9.5" font-family="ui-sans-serif,sans-serif">Ferrari</text>
+
+  <!-- McLaren [2015,2018) -->
+  <rect x="599" y="30" width="116" height="28" rx="2" fill="#7c5c9e"/>
+  <text x="657" y="49" text-anchor="middle" fill="white" font-size="9"   font-family="ui-sans-serif,sans-serif">McLaren</text>
+
+  <!-- ── x-axis ── -->
+  <line x1="55" y1="59" x2="715" y2="59" stroke="#ddd" stroke-width="1"/>
+
+  <!-- Year ticks and labels -->
+  <line x1="55"  y1="57" x2="55"  y2="64" stroke="#bbb" stroke-width="1"/>
+  <text x="55"   y="75" text-anchor="middle" fill="#999" font-size="8" font-family="ui-sans-serif,sans-serif">2001</text>
+
+  <line x1="133" y1="57" x2="133" y2="64" stroke="#bbb" stroke-width="1"/>
+  <text x="133"  y="75" text-anchor="middle" fill="#999" font-size="8" font-family="ui-sans-serif,sans-serif">2003</text>
+
+  <line x1="288" y1="57" x2="288" y2="64" stroke="#bbb" stroke-width="1"/>
+  <text x="288"  y="75" text-anchor="middle" fill="#999" font-size="8" font-family="ui-sans-serif,sans-serif">2007</text>
+
+  <line x1="327" y1="57" x2="327" y2="64" stroke="#bbb" stroke-width="1"/>
+  <text x="327"  y="75" text-anchor="middle" fill="#999" font-size="8" font-family="ui-sans-serif,sans-serif">2008</text>
+
+  <!-- 2010 tick: bolder, matches dashed line -->
+  <line x1="404" y1="57" x2="404" y2="64" stroke="#372649" stroke-width="1.5"/>
+  <text x="404"  y="75" text-anchor="middle" fill="#372649" font-size="8" font-family="ui-sans-serif,sans-serif" font-weight="bold">2010</text>
+
+  <line x1="599" y1="57" x2="599" y2="64" stroke="#bbb" stroke-width="1"/>
+  <text x="599"  y="75" text-anchor="middle" fill="#999" font-size="8" font-family="ui-sans-serif,sans-serif">2015</text>
+
+  <line x1="715" y1="57" x2="715" y2="64" stroke="#bbb" stroke-width="1"/>
+  <text x="715"  y="75" text-anchor="middle" fill="#999" font-size="8" font-family="ui-sans-serif,sans-serif">2018</text>
+
+  <!-- ── Multirange row visualisations (one row per constructor) ── -->
+
+  <!-- Row label -->
+  <text x="384" y="95" text-anchor="middle"
+        fill="#888" font-size="8.5" font-family="ui-sans-serif,sans-serif">
+    each bar below = one row in driver_contract_range (active_years column)
+  </text>
+
+  <!-- Renault row: {[2003,2007), [2008,2010)} -->
+  <text x="10" y="116" fill="#60b2d3" font-size="8" font-family="ui-sans-serif,sans-serif" font-weight="bold">Renault</text>
+
+  <!-- solid segment [2003,2007) x=133..288 -->
+  <rect x="133" y="108" width="155" height="10" rx="1" fill="#60b2d3" fill-opacity="0.7"/>
+  <!-- dashed gap [2007,2008) x=288..327 -->
+  <line x1="288" y1="113" x2="327" y2="113" stroke="#60b2d3" stroke-width="2" stroke-dasharray="4,3" opacity="0.5"/>
+  <!-- solid segment [2008,2010) x=327..404 -->
+  <rect x="327" y="108" width="77"  height="10" rx="1" fill="#60b2d3" fill-opacity="0.7"/>
+
+  <!-- Renault multirange literal -->
+  <text x="133" y="129" fill="#60b2d3" font-size="8.5" font-family="ui-monospace,monospace">
+    &#x27;{[2003,2007), [2008,2010)}&#x27;
+  </text>
+
+  <!-- McLaren row: {[2007,2008), [2015,2018)} -->
+  <text x="10" y="155" fill="#7c5c9e" font-size="8" font-family="ui-sans-serif,sans-serif" font-weight="bold">McLaren</text>
+
+  <!-- solid segment [2007,2008) x=288..327 -->
+  <rect x="288" y="147" width="39"  height="10" rx="1" fill="#7c5c9e" fill-opacity="0.7"/>
+  <!-- dashed gap [2008,2015) x=327..599 -->
+  <line x1="327" y1="152" x2="599" y2="152" stroke="#7c5c9e" stroke-width="2" stroke-dasharray="4,3" opacity="0.5"/>
+  <!-- solid segment [2015,2018) x=599..715 -->
+  <rect x="599" y="147" width="116" height="10" rx="1" fill="#7c5c9e" fill-opacity="0.7"/>
+
+  <!-- McLaren multirange literal -->
+  <text x="288" y="168" fill="#7c5c9e" font-size="8.5" font-family="ui-monospace,monospace">
+    &#x27;{[2007,2008), [2015,2018)}&#x27;
+  </text>
+
+  <!-- ── @> 2010 result annotation ── -->
+  <!-- label above bars -->
+  <text x="412" y="29" fill="#372649" font-size="9" font-family="ui-monospace,monospace" font-weight="bold">@&gt; 2010</text>
+
+  <!-- result label below McLaren row -->
+  <text x="412" y="188" fill="#bf4040" font-size="8.5" font-family="ui-sans-serif,sans-serif">
+    → Ferrari '{[2010,2015)}' contains 2010
+  </text>
+</svg>

--- a/themes/taop/layouts/partials/footer.html
+++ b/themes/taop/layouts/partials/footer.html
@@ -22,6 +22,8 @@
 	             <dd>The content of the book is available as a PDF and ePub file, and you can also download the SQL queries. The content is available over at <a href="https://members.theartofpostgresql.com/courses/the-art-of-postgresql/" target="_">https://members.theartofpostgresql.com/courses/the-art-of-postgresql/</a> from your student dashboard.</dd>
 	             <dt>I bought a previous edition. Do I get the 2026 update?</dt>
              <dd>Yes — the update is free for all existing purchasers. Log into your <a href="https://members.theartofpostgresql.com/courses/the-art-of-postgresql/" target="_blank" rel="noopener">ThriveCart account</a>, open the lesson, and download the updated PDF and ePub directly.</dd>
+             <dt>Is SQL still relevant now that AI writes queries?</dt>
+             <dd>Yes — <a href="/sql-and-ai/">here is why understanding SQL matters more than ever</a>, even when AI generates the code.</dd>
              <dt>Is there any DRM?</dt>
 	             <dd>No. There isn't even watermarking on the PDF. You own what you buy. The sources of data selected for the book are all available with Open Data types of licenses, and the book itself is copyright Dimitri Fontaine. All rights reserved.</dd>
 	             <dt>Any other questions?</dt>


### PR DESCRIPTION
## What this adds

### New `/sql-and-ai/` page
A standalone page making the case that SQL literacy matters *more* in the AI era, not less.
- Stat cards with sourced claims: BIRD benchmark 64% on complex queries, 65–75% of data job postings require SQL, 7 major PG releases since first edition
- Brent Ozar pullquote (January 2026, linked to source)
- Three section pointers linking to the YeSQL lessons below
- CTA block; `button_purple` colour inverted so it contrasts against the dark background

### Three YeSQL `sql-foundations` lessons

**`sql-and-ai-left-join.md`** — The JOIN That Silently Loses Rows  
`LEFT JOIN` neutralised by a `WHERE` on the right-side table; fix by filtering inside a subquery. Real F1 output: 208 constructors vs 10.

**`sql-and-ai-count.md`** — COUNT(*) After a JOIN Counts Rows, Not Things  
`COUNT(*)` after a join counts (driver, race) pairs, not distinct races. Includes a "Making the overcounting visible" section proving 953 × 4.3 = 4,136 analytically.

**`sql-and-ai-schema.md`** — The Schema Decision AI Cannot Make  
Updated to use `int4multirange` + `active_years` column name. Alonso's real two-stint McLaren/Renault career data demonstrates why multirange beats two separate rows. Exclusion constraint demo.

### SVG diagrams
- **`fig-count-join-explosion.svg`** — three-table ERD, 1:N cardinality arrows, result box comparing COUNT(*) = 4,136 vs COUNT(DISTINCT ra.raceid) = 953
- **`fig-multirange-career.svg`** — Alonso career timeline showing multirange row visualisation (solid segments + dashed gaps) and vertical @> 2010 containment query line

### Book updates page (`/book/updates/`)
- AI sentence split into its own `.bku-aside` paragraph with `fa-robot` icon (centre column of 3-col flex) and bold arrow link
- Gallery section label added above the figure grid
- `fa-gift` icon in the free banner enlarged to 3rem to match text height

### Footer FAQ
Added entry: *"Is SQL still relevant now that AI writes queries?"* linking to `/sql-and-ai/`