### PR TITLE
Course pages: canonical names, learner-outcome topics, cross-links, hero redesign

### DIFF
--- a/layouts/page/course-advanced-joins.html
+++ b/layouts/page/course-advanced-joins.html
@@ -69,17 +69,19 @@
       <p class="cp-part-meta">Core · 4 topics</p>
       <p class="cp-part-desc">INNER, LEFT, RIGHT, FULL OUTER, CROSS, and NATURAL joins with exact output semantics. Venn diagrams describe which rows survive — CROSS JOIN is the foundation of relational algebra, not a special case.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 19 — Understanding Relations and Joins</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">INNER JOIN</span><span class="cp-ch-topics">INNER JOIN discards rows with no match on either side.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">USING clause</span><span class="cp-ch-topics">USING merges the join column once; prefer it over NATURAL JOIN.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">LEFT JOIN, RIGHT JOIN, FULL OUTER JOIN, CROSS JOIN</span><span class="cp-ch-topics">Outer joins preserve unmatched rows; CROSS JOIN produces the Cartesian product.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">NULL behavior in joins</span><span class="cp-ch-topics">NULL comparisons yield NULL, not true, so three-valued logic governs join filtering.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">INNER JOIN</span><span class="cp-ch-topics">Keep only rows that have a matching record in both tables.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">USING clause</span><span class="cp-ch-topics">Write cleaner join syntax when both tables share a column name.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">LEFT JOIN, RIGHT JOIN, FULL OUTER JOIN, CROSS JOIN</span><span class="cp-ch-topics">Choose the right join type to include or exclude unmatched rows.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">NULL behavior in joins</span><span class="cp-ch-topics">Predict how NULL values affect match results in JOIN conditions.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/joins-and-relations/what-is-a-join/">What is a JOIN</a> · <a href="/yesql/sql-foundations/null-in-sql/">NULL in SQL: Three-Valued Logic</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-join-types.svg" alt="JOIN types">
-          <figcaption>INNER keeps matching rows, LEFT keeps all left rows, FULL OUTER keeps everything, CROSS produces every combination</figcaption>
+          <figcaption>See which rows survive each join type at a glance.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 01 · Three-table join</div>
@@ -115,17 +117,19 @@
       <p class="cp-part-meta">Core · 4 topics</p>
       <p class="cp-part-desc">Self-joins traverse hierarchies and compare rows within the same table. Non-equality joins match ranges. WITH RECURSIVE extends the pattern to arbitrary-depth graphs using SEARCH and CYCLE clauses.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 19 — Understanding Relations and Joins</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Progressive enrichment</span><span class="cp-ch-topics">Join from the fact table outward, adding one dimension at a time.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Composite FK joins</span><span class="cp-ch-topics">Omitting one component of a composite FK silently produces a Cartesian product.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Self-JOIN and the window-function alternative</span><span class="cp-ch-topics">Self-JOIN aliases the same table twice to compare adjacent or related rows.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Recursive reach with WITH RECURSIVE, SEARCH, and CYCLE (PostgreSQL 14)</span><span class="cp-ch-topics">WITH RECURSIVE walks a graph to any depth; CYCLE prevents infinite loops.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Progressive enrichment</span><span class="cp-ch-topics">Build multi-table queries incrementally without losing track of the data shape.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Composite FK joins</span><span class="cp-ch-topics">Avoid accidental row explosions when joining on composite keys.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Self-JOIN and the window-function alternative</span><span class="cp-ch-topics">Compare or link rows within the same table.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Recursive reach with WITH RECURSIVE, SEARCH, and CYCLE (PostgreSQL 14)</span><span class="cp-ch-topics">Traverse hierarchies and graphs to any depth safely.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/joins-and-relations/what-is-a-join/">What is a JOIN</a> · <a href="/yesql/joins-and-relations/with-recursive/">WITH RECURSIVE</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-f1db-erd.svg" alt="Multi-table ERD for progressive enrichment">
-          <figcaption>Progressive enrichment starts from a central fact table and adds dimension columns one join at a time — the ERD shows which tables connect and how.</figcaption>
+          <figcaption>See how a central fact table connects to its surrounding dimension tables.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 02 · Self-JOIN consecutive races</div>
@@ -158,16 +162,18 @@
       <p class="cp-part-meta">Core · 3 topics</p>
       <p class="cp-part-desc">Fan-out amplification happens silently when a join key is not unique on both sides. EXISTS and NOT EXISTS avoid double-counting; the NOT IN null trap is one of SQL's most common bugs.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 19 — Understanding Relations and Joins</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Non-equality joins</span><span class="cp-ch-topics">A join condition can use any boolean expression, not only equality.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">JOIN amplification</span><span class="cp-ch-topics">A one-to-many join multiplies rows, inflating every downstream aggregate.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">The COUNT(DISTINCT) fix and the aggregate-first fix</span><span class="cp-ch-topics">Use COUNT(DISTINCT) or aggregate before joining to collapse fan-out inflation.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Non-equality joins</span><span class="cp-ch-topics">Join tables on ranges, inequalities, or any condition — not just equality.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">JOIN amplification</span><span class="cp-ch-topics">Spot when a join silently inflates your aggregate results.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">The COUNT(DISTINCT) fix and the aggregate-first fix</span><span class="cp-ch-topics">Fix inflated aggregates caused by one-to-many join fan-out.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/joins-and-relations/join-output-cardinality/">JOIN Amplification &amp; Cardinality</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-join-amplification.svg" alt="JOIN amplification">
-          <figcaption>Joining on a non-unique key silently multiplies rows — fan-out amplification is the most common JOIN correctness bug</figcaption>
+          <figcaption>See how a non-unique join key silently multiplies rows.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 03 · JOIN amplification</div>
@@ -198,20 +204,22 @@ select c.name          as constructor,
       <p class="cp-part-meta">Core · 7 topics</p>
       <p class="cp-part-desc">LATERAL allows the right-hand subquery to reference columns from the left row. This enables top-N per group, kNN geographic search, and row-by-row correlated computation that a plain JOIN cannot express.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 19 — Understanding Relations and Joins</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">LATERAL as a manual loop</span><span class="cp-ch-topics">LATERAL re-evaluates its subquery for each outer row with outer columns available.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Top-N per group with LATERAL</span><span class="cp-ch-topics">LATERAL with LIMIT fetches top-N related rows independently for each outer row.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Reading a LATERAL execution plan</span><span class="cp-ch-topics">EXPLAIN shows LATERAL as a Nested Loop re-run once per outer row.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">LATERAL over geographic data: top-N cities per country</span><span class="cp-ch-topics">LATERAL fetches the top-N most-populous cities for each country in one pass.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">LATERAL with distance operator: kNN geographic search (GiST &lt;-&gt;)</span><span class="cp-ch-topics">LATERAL passes the outer row's location to a GiST nearest-neighbor lookup.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">LATERAL for social graph</span><span class="cp-ch-topics">LATERAL stops scanning each user's messages after finding the most-retweeted one.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">07</span><div><span class="cp-ch-title">Hashtag co-occurrence via array unnesting and self-join</span><span class="cp-ch-topics">Self-joining the unnested hashtag array produces all co-occurring pairs per tweet.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">LATERAL as a manual loop</span><span class="cp-ch-topics">Write per-row subqueries that reference the current row's values.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Top-N per group with LATERAL</span><span class="cp-ch-topics">Retrieve the top N related rows for every row in the outer query.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Reading a LATERAL execution plan</span><span class="cp-ch-topics">Read execution plans to understand how LATERAL queries are executed.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">LATERAL over geographic data: top-N cities per country</span><span class="cp-ch-topics">Retrieve top-N results per group from geographic data efficiently.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">LATERAL with distance operator: kNN geographic search (GiST &lt;-&gt;)</span><span class="cp-ch-topics">Find the nearest geographic points to each location in a dataset.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">LATERAL for social graph</span><span class="cp-ch-topics">Efficiently find the top post per user without scanning all rows.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">07</span><div><span class="cp-ch-title">Hashtag co-occurrence via array unnesting and self-join</span><span class="cp-ch-topics">Discover which topics appear together most often across posts.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/joins-and-relations/lateral-join-top-n/">LATERAL: Top-N Per Group</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-lateral-flow.svg" alt="LATERAL join flow">
-          <figcaption>LATERAL references left-row columns in the right-hand subquery — enabling top-N per group in a single scan</figcaption>
+          <figcaption>Understand how LATERAL feeds each outer row into the inner subquery.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 04 · LATERAL Top-N per driver</div>
@@ -252,16 +260,18 @@ select c.name          as constructor,
       <p class="cp-part-meta">Core · 3 topics</p>
       <p class="cp-part-desc">Combining GROUP BY and window functions with JOINs requires careful ordering. FILTER and CASE inside aggregates often eliminate the need for a second join pass.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 19 — Understanding Relations and Joins</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">GROUP BY after JOIN</span><span class="cp-ch-topics">Aggregate after joining only when each joined row represents exactly one event.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Filtered aggregates with FILTER clause</span><span class="cp-ch-topics">FILTER clause applies a per-aggregate condition in a single table scan.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Window functions over joined data</span><span class="cp-ch-topics">Window functions run after joins, operating over the fully enriched joined relation.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">GROUP BY after JOIN</span><span class="cp-ch-topics">Know when it is safe to aggregate after joining, and when it is not.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Filtered aggregates with FILTER clause</span><span class="cp-ch-topics">Compute multiple conditional totals in a single pass over the data.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Window functions over joined data</span><span class="cp-ch-topics">Apply running totals and rankings over joined, multi-table result sets.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/joins-and-relations/join-output-cardinality/">JOIN Amplification &amp; Cardinality</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-count-join-explosion.svg" alt="Join amplification before aggregation">
-          <figcaption>Joining before aggregating can inflate row counts — aggregate-then-join or FILTER after the fact prevents double-counting without losing required columns.</figcaption>
+          <figcaption>See why aggregation order relative to joins affects your totals.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 05 · Cumulative championship points</div>
@@ -298,20 +308,22 @@ select c.name          as constructor,
       <p class="cp-part-meta">Core · 7 topics</p>
       <p class="cp-part-desc">WITH (CTEs), nested subqueries, and LATERAL chain together into readable multi-step computations. The MATERIALIZED option controls whether PostgreSQL treats a CTE as a fence or inlines it as a subquery.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 19 — Understanding Relations and Joins</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">CTEs for readability and multi-step logic</span><span class="cp-ch-topics">WITH clauses name intermediate relations, turning complex queries into sequential readable steps.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Subqueries in join position</span><span class="cp-ch-topics">A subquery in FROM pre-aggregates before joining, preventing fan-out amplification.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Semi-JOIN: EXISTS</span><span class="cp-ch-topics">EXISTS stops at the first match, preventing fan-out duplication of outer rows.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Anti-JOIN: NOT EXISTS</span><span class="cp-ch-topics">NOT EXISTS keeps rows that have no match on the inner side.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">The NOT IN null trap</span><span class="cp-ch-topics">NOT IN silently returns zero rows when the subquery contains any NULL.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Set operators: UNION, INTERSECT, EXCEPT</span><span class="cp-ch-topics">UNION, INTERSECT, and EXCEPT combine same-schema relations vertically, deduplicating by default.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">07</span><div><span class="cp-ch-title">DISTINCT ON</span><span class="cp-ch-topics">DISTINCT ON picks one row per group; ORDER BY selects which row.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">CTEs for readability and multi-step logic</span><span class="cp-ch-topics">Break a complex query into named, readable steps.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Subqueries in join position</span><span class="cp-ch-topics">Pre-aggregate data before joining to prevent row count inflation.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Semi-JOIN: EXISTS</span><span class="cp-ch-topics">Filter rows based on whether a related record exists anywhere.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Anti-JOIN: NOT EXISTS</span><span class="cp-ch-topics">Find rows that have no matching record in another table.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">The NOT IN null trap</span><span class="cp-ch-topics">Avoid a silent bug that can wipe out all results in a filter.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Set operators: UNION, INTERSECT, EXCEPT</span><span class="cp-ch-topics">Combine, overlap, or subtract result sets from multiple queries.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">07</span><div><span class="cp-ch-title">DISTINCT ON</span><span class="cp-ch-topics">Pick exactly one row per group based on a defined sort order.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/joins-and-relations/what-is-a-join/">What is a JOIN</a> · <a href="/yesql/sql-foundations/null-in-sql/">NULL in SQL: Three-Valued Logic</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-cte-pipeline.svg" alt="CTE pipeline for query composition">
-          <figcaption>CTEs decompose a complex query into named steps — EXISTS and NOT EXISTS express semi-joins and anti-joins more explicitly than IN/NOT IN and avoid the NOT IN null trap.</figcaption>
+          <figcaption>See how CTEs chain query steps and how EXISTS avoids the NOT IN trap.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 06 · Anti-JOIN NOT EXISTS</div>
@@ -350,18 +362,20 @@ select c.name          as constructor,
       <p class="cp-part-meta">Advanced · 5 topics</p>
       <p class="cp-part-desc">Hash Join, Nested Loop, and Merge Join — how the planner chooses and what to do when the estimate is wrong. Index-nested-loop for selective predicates, parallel hash for large equi-joins.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 19 — Understanding Relations and Joins</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Three join algorithms: Nested Loop, Hash Join, Merge Join</span><span class="cp-ch-topics">Each join algorithm suits different table sizes, sort orders, and index availability.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Reading execution plans with EXPLAIN (ANALYZE, BUFFERS)</span><span class="cp-ch-topics">EXPLAIN (ANALYZE, BUFFERS) shows actual rows, chosen algorithm, and buffer statistics.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Hash Join: Batches &gt; 1 means spill to disk</span><span class="cp-ch-topics">Hash Join builds a hash table; Batches &gt; 1 signals work_mem overflow.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Index impact on join performance</span><span class="cp-ch-topics">Indexes on join columns replace sequential inner scans with index lookups.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Join order and planner limits (join_collapse_limit, geqo_threshold)</span><span class="cp-ch-topics">Past join_collapse_limit the planner keeps your join order; past geqo_threshold uses GEQO.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Three join algorithms: Nested Loop, Hash Join, Merge Join</span><span class="cp-ch-topics">Recognize which join algorithm PostgreSQL will choose for a given query.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Reading execution plans with EXPLAIN (ANALYZE, BUFFERS)</span><span class="cp-ch-topics">Read query execution plans to diagnose join performance issues.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Hash Join: Batches &gt; 1 means spill to disk</span><span class="cp-ch-topics">Identify when a Hash Join is spilling to disk and how to fix it.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Index impact on join performance</span><span class="cp-ch-topics">Understand how indexes change which join algorithm PostgreSQL picks.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Join order and planner limits (join_collapse_limit, geqo_threshold)</span><span class="cp-ch-topics">Control how PostgreSQL explores join orderings in complex queries.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/joins-and-relations/join-output-cardinality/">JOIN Amplification &amp; Cardinality</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-join-operators.svg" alt="Join operator internals">
-          <figcaption>Hash Join, Nested Loop, and Merge Join each have a different cost shape — the planner chooses based on table size and selectivity estimates</figcaption>
+          <figcaption>Compare the cost shape of each join algorithm at a glance.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 07 · EXPLAIN Hash Join</div>
@@ -389,18 +403,19 @@ select d.nationality,
       <p class="cp-part-meta">Architect · 5 topics</p>
       <p class="cp-part-desc">Normalization vs pre-joined denormalized tables for read-heavy workloads. Foreign data wrappers for cross-schema JOINs, join planning for partitioned tables, and when to move joins out of the database.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 19 — Understanding Relations and Joins</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Materialized views</span><span class="cp-ch-topics">Materialized views precompute and store join results to speed repeated reads.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Confident queries: chinook (enforced FKs) vs f1db (no FKs)</span><span class="cp-ch-topics">Enforced FKs give the planner join-success guarantees; absent FKs force conservative plans.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Denormalization strategy</span><span class="cp-ch-topics">Collapse a join by storing its result directly in the reading table.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Access patterns drive schema design</span><span class="cp-ch-topics">Hot queries should drive index and materialization decisions, not schema purity.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Course synthesis: CTEs + aggregation-before-join + window functions</span><span class="cp-ch-topics">Pre-aggregate in CTEs, join the summaries, and rank with a window function.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Materialized views</span><span class="cp-ch-topics">Cache expensive join results to serve repeated reads without recomputation.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Confident queries: chinook (enforced FKs) vs f1db (no FKs)</span><span class="cp-ch-topics">Understand how foreign key declarations affect query planning.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Denormalization strategy</span><span class="cp-ch-topics">Eliminate a join by embedding its data directly in the querying table.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Access patterns drive schema design</span><span class="cp-ch-topics">Let your most critical queries guide schema and indexing decisions.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Course synthesis: CTEs + aggregation-before-join + window functions</span><span class="cp-ch-topics">Combine CTEs, aggregation, and window functions into a complete solution.</span></div></div>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-chinook-erd.svg" alt="Chinook ERD: fully-declared foreign keys">
-          <figcaption>Chinook's fully-declared foreign keys give the planner join-elimination opportunities — schema design decisions about normalization cascade directly into execution plan quality.</figcaption>
+          <figcaption>See how declared foreign keys open up planner optimizations.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 08 · Normalized vs pre-aggregated</div>

--- a/layouts/page/course-aggregation.html
+++ b/layouts/page/course-aggregation.html
@@ -69,17 +69,19 @@
       <p class="cp-part-meta">Core · 4 topics</p>
       <p class="cp-part-desc">GROUP BY collapses rows into groups and the evaluation order — WHERE → GROUP BY → HAVING → SELECT — determines which clauses can reference aggregate results. This module builds that mental model against F1 race data.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 16 — Group By, Having, With, Union All</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">GROUP BY semantics and evaluation order</span><span class="cp-ch-topics">GROUP BY collapses rows into groups keyed by the specified columns.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Aggregate functions: SUM, COUNT, AVG, MIN, MAX</span><span class="cp-ch-topics">Aggregate functions reduce every group of rows to a single computed value.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">NULL handling and boolean aggregates</span><span class="cp-ch-topics">SUM ignores NULLs; COUNT(*) includes them; bool_and and bool_or aggregate boolean conditions.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Row vs group context</span><span class="cp-ch-topics">Every non-aggregate SELECT column must appear in the GROUP BY clause.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">GROUP BY semantics and evaluation order</span><span class="cp-ch-topics">Understand how GROUP BY organizes query results into distinct groups.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Aggregate functions: SUM, COUNT, AVG, MIN, MAX</span><span class="cp-ch-topics">Apply COUNT, SUM, AVG, MIN, and MAX to summarize data within groups.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">NULL handling and boolean aggregates</span><span class="cp-ch-topics">Spot how NULL values silently change aggregate totals and boolean results.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Row vs group context</span><span class="cp-ch-topics">Know which columns must be listed in GROUP BY and why.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/sql-foundations/group-by-semantics/">GROUP BY and HAVING</a> · <a href="/yesql/aggregation/sql-aggregates/">Common Aggregate Functions</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-select-order.svg" alt="SQL clause evaluation order">
-          <figcaption>SQL clauses evaluate in a fixed order — WHERE filters rows before GROUP BY forms groups, HAVING filters groups after aggregation</figcaption>
+          <figcaption>How the SQL evaluation order determines which clauses can reference aggregate results.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 01 · GROUP BY decade</div>
@@ -106,17 +108,19 @@
       <p class="cp-part-meta">Core · 4 topics</p>
       <p class="cp-part-desc">COUNT(col) excludes NULLs while COUNT(*) does not. COUNT DISTINCT carries hidden performance costs. This module traces every correctness trap with working examples on real datasets.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 16 — Group By, Having, With, Union All</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Duplicate rows and COUNT DISTINCT</span><span class="cp-ch-topics">Joining before aggregating inflates counts; COUNT DISTINCT removes duplicates within each group.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">WHERE vs HAVING</span><span class="cp-ch-topics">HAVING filters groups after aggregation, where WHERE cannot reference aggregate results.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Filtered aggregates with FILTER clause</span><span class="cp-ch-topics">FILTER computes conditional counts and sums in one scan without CASE expressions.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">DISTINCT vs GROUP BY</span><span class="cp-ch-topics">SELECT DISTINCT and GROUP BY deduplicate identically; GROUP BY also supports aggregates.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Duplicate rows and COUNT DISTINCT</span><span class="cp-ch-topics">Avoid inflated counts caused by joining before aggregating.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">WHERE vs HAVING</span><span class="cp-ch-topics">Choose the right filter clause for conditions before or after grouping.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Filtered aggregates with FILTER clause</span><span class="cp-ch-topics">Compute multiple conditional aggregates in a single pass over the data.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">DISTINCT vs GROUP BY</span><span class="cp-ch-topics">Know when to reach for DISTINCT versus GROUP BY to remove duplicates.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/sql-foundations/group-by-semantics/">GROUP BY and HAVING</a> · <a href="/yesql/aggregation/sql-aggregates/">Common Aggregate Functions</a> · <a href="/yesql/aggregation/filter-clause/">The FILTER Clause</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-select-order.svg" alt="SQL evaluation order">
-          <figcaption>WHERE filters rows before grouping; HAVING filters groups after aggregation — the SQL evaluation order determines which clause can reference aggregate results.</figcaption>
+          <figcaption>Where each filter clause sits in evaluation and what values it can see.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 02 · FILTER for accident rate</div>
@@ -153,16 +157,18 @@
       <p class="cp-part-meta">Core · 3 topics</p>
       <p class="cp-part-desc">Window functions combined with GROUP BY enable multi-level summaries without running the query twice. Nested subqueries let you aggregate over aggregates cleanly.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 16 — Group By, Having, With, Union All</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">CTEs for multi-step aggregation</span><span class="cp-ch-topics">A CTE names intermediate results so subsequent query steps can reference them.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Chaining CTEs</span><span class="cp-ch-topics">Chained CTEs work around PostgreSQL's prohibition on nested aggregates like max(sum(…)).</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Nested aggregation with multiple CTEs and GROUPING SETS</span><span class="cp-ch-topics">Multiple CTEs chain aggregation steps that would require illegal nested aggregate calls.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">CTEs for multi-step aggregation</span><span class="cp-ch-topics">Structure complex queries by naming and reusing intermediate aggregation results.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Chaining CTEs</span><span class="cp-ch-topics">Aggregate over aggregated values by chaining query steps together.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Nested aggregation with multiple CTEs and GROUPING SETS</span><span class="cp-ch-topics">Build multi-level summaries without repeating expensive table scans.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/aggregation/sql-aggregates/">Common Aggregate Functions</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-cte-pipeline.svg" alt="CTE pipeline for multi-step aggregation">
-          <figcaption>A chain of CTEs lets you aggregate at multiple levels in one readable query — each step builds on the previous one's grouped result.</figcaption>
+          <figcaption>How chained CTEs pass aggregated results between steps in a single query.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 03 · Per-decade top scorer</div>
@@ -207,17 +213,18 @@ select dp.decade,
       <p class="cp-part-meta">Core · 4 topics</p>
       <p class="cp-part-desc">GROUPING SETS computes multiple GROUP BY combinations in one scan. ROLLUP adds hierarchical subtotals; CUBE adds all cross-tabulations. GROUPING() distinguishes a NULL result from a missing row.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 16 — Group By, Having, With, Union All</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">GROUPING SETS</span><span class="cp-ch-topics">GROUPING SETS produces multiple grouping combinations from a single table scan.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">ROLLUP</span><span class="cp-ch-topics">ROLLUP generates subtotals for each column prefix, down to the grand total.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">CUBE</span><span class="cp-ch-topics">CUBE generates subtotals for every possible subset of the listed columns.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">GROUPING() function</span><span class="cp-ch-topics">GROUPING() flags synthetic NULLs produced by ROLLUP or CUBE subtotal rows.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">GROUPING SETS</span><span class="cp-ch-topics">Generate several grouping combinations in one query without repeating the scan.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">ROLLUP</span><span class="cp-ch-topics">Add hierarchical subtotals and a grand total alongside detail rows.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">CUBE</span><span class="cp-ch-topics">Cross-tabulate totals across all combinations of grouping columns at once.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">GROUPING() function</span><span class="cp-ch-topics">Distinguish subtotal rows from genuine NULL values in aggregation results.</span></div></div>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-grouping-sets-lattice.svg" alt="Grouping sets lattice">
-          <figcaption>CUBE computes all subsets; ROLLUP follows the hierarchical chain; GROUPING SETS lets you pick exactly which combinations to compute</figcaption>
+          <figcaption>How GROUPING SETS, ROLLUP, and CUBE differ in the combinations they produce.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 04 · ROLLUP subtotals</div>
@@ -248,17 +255,19 @@ select dp.decade,
       <p class="cp-part-meta">Core · 4 topics</p>
       <p class="cp-part-desc">The FILTER clause computes conditional counts and sums in a single pass — far faster than multiple CASE expressions. Ordered-set aggregates (percentile_cont, mode) extend what GROUP BY can express.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 16 — Group By, Having, With, Union All</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Aggregation with joins</span><span class="cp-ch-topics">Aggregating before joining prevents the join from amplifying the counts being computed.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Conditional aggregation with CASE inside SUM</span><span class="cp-ch-topics">A CASE inside SUM routes rows into separate buckets in one scan.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Window functions vs GROUP BY</span><span class="cp-ch-topics">GROUP BY collapses rows; window functions add aggregates without collapsing the result.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">A complete reporting query: FILTER, HAVING, COUNT DISTINCT combined</span><span class="cp-ch-topics">CTE scope, FILTER, HAVING, and COUNT DISTINCT combine into one constructor report.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Aggregation with joins</span><span class="cp-ch-topics">Prevent inflated counts by aggregating before joining instead of after.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Conditional aggregation with CASE inside SUM</span><span class="cp-ch-topics">Split totals into multiple conditional categories within a single query.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Window functions vs GROUP BY</span><span class="cp-ch-topics">Decide when a window function is a better fit than GROUP BY.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">A complete reporting query: FILTER, HAVING, COUNT DISTINCT combined</span><span class="cp-ch-topics">Combine multiple aggregation techniques into one complete, accurate report.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/aggregation/sql-aggregates/">Common Aggregate Functions</a> · <a href="/yesql/aggregation/filter-clause/">The FILTER Clause</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-aggregate-filter.svg" alt="FILTER clause">
-          <figcaption>FILTER runs multiple conditional aggregates in a single pass without CASE expressions or subqueries</figcaption>
+          <figcaption>How conditional aggregation computes multiple bucket totals in one pass.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 05 · Constructor report</div>
@@ -301,17 +310,18 @@ having count(*) &gt;= 20
       <p class="cp-part-meta">Core · 4 topics</p>
       <p class="cp-part-desc">HashAgg vs SortedAgg, spill to disk, and partial aggregation in parallel plans. This module explains when to pre-aggregate into a materialized view versus aggregating live at query time.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 16 — Group By, Having, With, Union All</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Hash vs sort aggregation</span><span class="cp-ch-topics">Hash aggregation builds an in-memory table; sort aggregation requires sorted input rows.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Reading aggregation plans</span><span class="cp-ch-topics">HashAggregate uses a hash table; GroupAggregate processes pre-sorted rows group by group.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Pre-aggregation strategies with materialized views</span><span class="cp-ch-topics">A materialized view shifts repeated aggregation cost to one-time refresh time.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Profiling with EXPLAIN (ANALYZE, BUFFERS)</span><span class="cp-ch-topics">EXPLAIN ANALYZE reports actual timings and actual rows to reveal planner misfires.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Hash vs sort aggregation</span><span class="cp-ch-topics">Predict which aggregation strategy PostgreSQL will choose for a given query.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Reading aggregation plans</span><span class="cp-ch-topics">Read an EXPLAIN plan to identify which aggregation node your query uses.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Pre-aggregation strategies with materialized views</span><span class="cp-ch-topics">Decide when pre-aggregating into a stored view pays off over live aggregation.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Profiling with EXPLAIN (ANALYZE, BUFFERS)</span><span class="cp-ch-topics">Profile a slow aggregation query to locate and fix the bottleneck.</span></div></div>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-node-types.svg" alt="Aggregation plan node types">
-          <figcaption>Hash aggregation builds a hash table in memory; when it spills to disk (Batches &gt; 1), performance drops sharply — EXPLAIN reveals which strategy was chosen.</figcaption>
+          <figcaption>When and why aggregation spills to disk, and how to see it in EXPLAIN.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 06 · EXPLAIN HashAggregate</div>
@@ -338,19 +348,21 @@ having count(*) &gt;= 20
       <p class="cp-part-meta">Advanced · 6 topics</p>
       <p class="cp-part-desc">Reliable reporting queries stay correct as data grows — no implicit column dependencies, no unstable GROUP BY expressions, behavior verified with realistic data volumes before going to production.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 16 — Group By, Having, With, Union All</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Idempotent aggregation</span><span class="cp-ch-topics">A WHERE clause with constant time bounds makes a reporting query idempotent.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Ordered-set aggregates: percentile_cont, percentile_disc, mode()</span><span class="cp-ch-topics">percentile_cont interpolates the exact quantile; percentile_disc picks the nearest actual data value.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Gap filling with generate_series</span><span class="cp-ch-topics">A LEFT JOIN to generate_series fills gaps so every period row appears.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Datetime fence-post trap</span><span class="cp-ch-topics">Date literals in BETWEEN are cast to midnight, dropping later events silently.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Drift detection with LAG()</span><span class="cp-ch-topics">LAG() makes the previous period's value available to flag unexpected metric shifts.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Bi-temporal modeling</span><span class="cp-ch-topics">Valid time tracks real-world truth; transaction time tracks database knowledge.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Idempotent aggregation</span><span class="cp-ch-topics">Write reporting queries that remain correct no matter how many times they run.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Ordered-set aggregates: percentile_cont, percentile_disc, mode()</span><span class="cp-ch-topics">Compute median, percentile, and mode summaries over grouped data.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Gap filling with generate_series</span><span class="cp-ch-topics">Ensure every time period appears in a report even when source rows are missing.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Datetime fence-post trap</span><span class="cp-ch-topics">Avoid accidentally dropping events at the boundary of a date-range filter.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Drift detection with LAG()</span><span class="cp-ch-topics">Detect unexpected changes in a metric by comparing each period to the previous one.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Bi-temporal modeling</span><span class="cp-ch-topics">Model data with two independent timelines: when it was true and when it was stored.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/aggregation/percentiles-in-one-query/">Percentiles &amp; Ordered-Set Aggregates</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-range-band-timeline.svg" alt="Time bands for gap filling">
-          <figcaption>Bi-temporal queries and gap filling both reason over time bands — generate_series anchors the timeline so missing periods surface as NULLs rather than disappearing.</figcaption>
+          <figcaption>How time bands surface missing periods and bi-temporal record boundaries.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 07 · Gap filling</div>
@@ -390,18 +402,19 @@ select s.season,
       <p class="cp-part-meta">Architect · 5 topics</p>
       <p class="cp-part-desc">MERGE, upsert patterns, and incremental aggregation maintain summary tables at scale. Trade-offs between query-time aggregation, periodic rollups, and streaming pre-aggregation.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 16 — Group By, Having, With, Union All</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Materialized views</span><span class="cp-ch-topics">REFRESH MATERIALIZED VIEW updates the stored snapshot; CONCURRENTLY avoids locking concurrent readers.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Incremental aggregation with upsert (INSERT … ON CONFLICT)</span><span class="cp-ch-topics">Upsert keeps the summary table current by overwriting stale rows without duplicates.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">ETL/ELT patterns and MERGE (PostgreSQL 15+)</span><span class="cp-ch-topics">MERGE handles all three DML operations atomically where ON CONFLICT only upserts.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">OLAP vs OLTP trade-offs</span><span class="cp-ch-topics">OLTP serves selective row lookups; OLAP scans wide ranges to aggregate results.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Distributed aggregation with Citus</span><span class="cp-ch-topics">Citus distributes tables across worker shards for horizontal scaling inside PostgreSQL.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Materialized views</span><span class="cp-ch-topics">Refresh pre-computed summaries without blocking concurrent read queries.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Incremental aggregation with upsert (INSERT … ON CONFLICT)</span><span class="cp-ch-topics">Keep a summary table current by safely overwriting stale rows on reload.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">ETL/ELT patterns and MERGE (PostgreSQL 15+)</span><span class="cp-ch-topics">Apply inserts, updates, and deletes atomically in a single data-load statement.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">OLAP vs OLTP trade-offs</span><span class="cp-ch-topics">Choose the right database design based on your query's selectivity pattern.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Distributed aggregation with Citus</span><span class="cp-ch-topics">Scale aggregation to more data than fits on one server, staying within PostgreSQL.</span></div></div>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-citus-arch.svg" alt="Citus distributed architecture: coordinator, workers, shards">
-          <figcaption>Citus routes SQL from a coordinator to worker shards in parallel — distributed tables are sharded by key, reference tables are replicated to every worker.</figcaption>
+          <figcaption>How a distributed query splits aggregation work across coordinator and worker nodes.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 08 · Idempotent upsert</div>

--- a/layouts/page/course-data-modeling.html
+++ b/layouts/page/course-data-modeling.html
@@ -70,18 +70,20 @@
       <p class="cp-part-meta">Core · 5 topics</p>
       <p class="cp-part-desc">Normal forms eliminate update, insertion, and deletion anomalies by storing each fact in exactly one place. This module connects relational theory to real PostgreSQL schema decisions using the Chinook and F1 datasets.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-6">Chapter 29 — Normalization</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Normal forms and the three database anomalies</span><span class="cp-ch-topics">Redundant storage of facts causes update, insertion, and deletion anomalies.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">First through fifth normal forms</span><span class="cp-ch-topics">Each normal form from 1NF through BCNF eliminates one class of redundancy.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Contrasting schemas: chinook (enforced FKs) vs f1db (no FKs)</span><span class="cp-ch-topics">Chinook declares FK constraints on every relationship; f1db declares none.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Constraint inventory via pg_constraint</span><span class="cp-ch-topics">Querying pg_constraint reveals which schemas declare FK constraints and which do not.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Foreign key enforcement trade-offs</span><span class="cp-ch-topics">A missing FK allows referentially invalid rows to land without error.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Normal forms and the three database anomalies</span><span class="cp-ch-topics">Identify the three anomalies that redundant data storage creates.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">First through fifth normal forms</span><span class="cp-ch-topics">Apply each normal form to eliminate a specific class of redundancy.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Contrasting schemas: chinook (enforced FKs) vs f1db (no FKs)</span><span class="cp-ch-topics">Compare how two real datasets differ in their use of foreign key constraints.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Constraint inventory via pg_constraint</span><span class="cp-ch-topics">Audit a live database schema to see which constraints are declared.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Foreign key enforcement trade-offs</span><span class="cp-ch-topics">Predict the data integrity risks of omitting foreign key constraints.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/sql-foundations/database-anomalies/">The Three Database Anomalies</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-normal-forms.svg" alt="Normal forms">
-          <figcaption>Each normal form removes a specific class of anomaly — 1NF through BCNF narrows what facts a table is allowed to express</figcaption>
+          <figcaption>Understand how each normal form systematically narrows redundancy.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 01 · Insertion anomaly</div>
@@ -119,19 +121,21 @@ rollback;</code></pre>
       <p class="cp-part-meta">Core · 6 topics</p>
       <p class="cp-part-desc">Natural vs surrogate keys, UUID generation strategies, GENERATED AS IDENTITY, and CHECK constraints. The right primary key choice affects join performance, index size, and schema evolution for decades.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-6">Chapter 29 — Normalization</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Natural vs surrogate primary keys</span><span class="cp-ch-topics">Natural keys enforce domain uniqueness; surrogate keys keep joins compact.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">UUID generation with gen_random_uuid() and uuidv7()</span><span class="cp-ch-topics">gen_random_uuid() produces random v4 UUIDs; uuidv7() adds monotonic timestamp ordering.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Check constraints</span><span class="cp-ch-topics">A CHECK constraint validates a column expression on every insert and update.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Generated stored columns (GENERATED ALWAYS AS STORED)</span><span class="cp-ch-topics">A generated column is computed from other columns and persisted automatically.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">NOT NULL migration pattern</span><span class="cp-ch-topics">Backfill NULLs before adding NOT NULL to avoid failing on existing rows.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Exclusion constraints with btree_gist</span><span class="cp-ch-topics">btree_gist enables exclusion constraints mixing equality and range-overlap operators.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Natural vs surrogate primary keys</span><span class="cp-ch-topics">Choose between natural and surrogate keys for a table's primary key.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">UUID generation with gen_random_uuid() and uuidv7()</span><span class="cp-ch-topics">Select the right UUID generation strategy for your workload.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Check constraints</span><span class="cp-ch-topics">Enforce column-level business rules with declarative check constraints.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Generated stored columns (GENERATED ALWAYS AS STORED)</span><span class="cp-ch-topics">Add computed columns that stay in sync with their source data automatically.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">NOT NULL migration pattern</span><span class="cp-ch-topics">Safely add a NOT NULL column to a live table without breaking existing rows.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Exclusion constraints with btree_gist</span><span class="cp-ch-topics">Prevent overlapping bookings or contracts at the database level.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/data-schema-design/fk-constraints-trust/">Foreign Keys &amp; Planner Trust</a> · <a href="/yesql/data-schema-design/range-types/">Range Types &amp; Temporal Constraints</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-btree-page-layout.svg" alt="B-tree page layout for primary keys">
-          <figcaption>Random UUIDs scatter inserts across the B-tree; sequential UUIDs (uuidv7) or GENERATED AS IDENTITY concentrate writes at the rightmost leaf page.</figcaption>
+          <figcaption>See how key choice affects B-tree write patterns and index bloat.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 02 · Exclusion constraint</div>
@@ -167,18 +171,20 @@ rollback;</code></pre>
       <p class="cp-part-meta">Core · 5 topics</p>
       <p class="cp-part-desc">Foreign key ON DELETE and ON UPDATE actions encode referential integrity rules directly in the schema. Junction tables, self-referential FKs, and deferrable constraints handle the edge cases.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-6">Chapter 29 — Normalization</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Hierarchy chains and fan-out</span><span class="cp-ch-topics">Joining before aggregating multiplies row counts; aggregate at the leaf level first.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Junction tables</span><span class="cp-ch-topics">A composite-PK junction table pairs two entities and prevents duplicate associations.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Self-referential relationships and recursive CTEs</span><span class="cp-ch-topics">A self-referential FK encodes a tree; a recursive CTE traverses it.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Nullable foreign keys</span><span class="cp-ch-topics">A NULL FK silently excludes the row from INNER JOINs.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Foreign key actions: CASCADE, SET NULL, RESTRICT</span><span class="cp-ch-topics">CASCADE deletes children, SET NULL nullifies the FK, RESTRICT blocks the delete.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Hierarchy chains and fan-out</span><span class="cp-ch-topics">Avoid inflated counts by aggregating before joining across relationships.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Junction tables</span><span class="cp-ch-topics">Model many-to-many relationships without creating duplicate associations.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Self-referential relationships and recursive CTEs</span><span class="cp-ch-topics">Traverse hierarchical data stored as a self-referential table structure.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Nullable foreign keys</span><span class="cp-ch-topics">Predict which rows disappear from joins when foreign keys are nullable.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Foreign key actions: CASCADE, SET NULL, RESTRICT</span><span class="cp-ch-topics">Choose the right referential action for each parent-child relationship.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/data-schema-design/fk-constraints-trust/">Foreign Keys &amp; Planner Trust</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-fk-actions-erd.svg" alt="Foreign key actions ERD">
-          <figcaption>ON DELETE and ON UPDATE actions encode referential integrity rules directly in the schema — no application code required</figcaption>
+          <figcaption>Understand how schema-level actions replace application-level integrity code.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 03 · Junction table query</div>
@@ -212,19 +218,21 @@ rollback;</code></pre>
       <p class="cp-part-meta">Core · 6 topics</p>
       <p class="cp-part-desc">B-tree, GiST, GIN, BRIN, partial, and covering indexes each suit specific access patterns. Composite index column order and operator class selection determine whether a query hits the index at all.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-6">Chapter 29 — Normalization</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Index types: B-tree, GiST, GIN, SP-GiST, BRIN, Hash, RUM, Bloom</span><span class="cp-ch-topics">B-tree handles ranges; GIN handles containment; BRIN handles append-only time series.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Fillfactor and HOT updates</span><span class="cp-ch-topics">Heap fillfactor controls HOT update eligibility when only non-indexed columns are modified.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Unique constraints and partial unique indexes</span><span class="cp-ch-topics">A partial index enforces UNIQUE only on rows satisfying the WHERE predicate.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Composite indexes, partial indexes, covering indexes (INCLUDE)</span><span class="cp-ch-topics">The INCLUDE clause stores extra columns in leaf pages, enabling index-only scans.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Functional / expression indexes</span><span class="cp-ch-topics">Expression indexes store precomputed values and eliminate function calls on every read.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Index column options: ASC/DESC, NULLS FIRST/LAST, operator classes</span><span class="cp-ch-topics">Index sort direction must match ORDER BY to skip the sort step.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Index types: B-tree, GiST, GIN, SP-GiST, BRIN, Hash, RUM, Bloom</span><span class="cp-ch-topics">Select the right index type for each query's access pattern.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Fillfactor and HOT updates</span><span class="cp-ch-topics">Reduce index bloat by tuning fillfactor for frequently updated tables.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Unique constraints and partial unique indexes</span><span class="cp-ch-topics">Enforce conditional uniqueness on a filtered subset of rows.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Composite indexes, partial indexes, covering indexes (INCLUDE)</span><span class="cp-ch-topics">Design covering indexes that serve queries entirely from the index.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Functional / expression indexes</span><span class="cp-ch-topics">Speed up function-based filters without rewriting the application query.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Index column options: ASC/DESC, NULLS FIRST/LAST, operator classes</span><span class="cp-ch-topics">Align index sort options so the planner eliminates the sort step.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/data-schema-design/fk-constraints-trust/">Foreign Keys &amp; Planner Trust</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-index-types.svg" alt="Index types">
-          <figcaption>B-tree, GiST, GIN, BRIN, and HASH each suit a different access pattern — choosing wrong is expensive to fix later</figcaption>
+          <figcaption>Match each index type to the queries it was designed to accelerate.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 04 · Partial index</div>
@@ -258,18 +266,20 @@ rollback;</code></pre>
       <p class="cp-part-meta">Core · 5 topics</p>
       <p class="cp-part-desc">Star schemas, JSONB for semi-structured data, and range types for temporal coverage. This module shows when to denormalize deliberately and how to document the trade-off in the schema itself.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-6">Chapter 32 — Denormalization</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">The star join</span><span class="cp-ch-topics">Fact and dimension tables form a star schema optimized for analytical aggregations.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Intentional denormalisation for historical accuracy</span><span class="cp-ch-topics">Deliberate denormalization preserves historical values that a live FK join would overwrite.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Materialized view vs live query</span><span class="cp-ch-topics">A materialized view caches a query result, trading freshness for read speed.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Three-level MV dependency chain with concurrent refresh</span><span class="cp-ch-topics">Three chained materialized views refreshed concurrently propagate aggregations without blocking readers.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Arrays to reduce row count (array_agg)</span><span class="cp-ch-topics">array_agg collapses per-group rows into one array, reducing the result count.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">The star join</span><span class="cp-ch-topics">Design a star schema that accelerates multi-dimensional analytical queries.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Intentional denormalisation for historical accuracy</span><span class="cp-ch-topics">Decide when to denormalize deliberately to preserve historical values over time.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Materialized view vs live query</span><span class="cp-ch-topics">Choose between a live query and a materialized view based on freshness needs.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Three-level MV dependency chain with concurrent refresh</span><span class="cp-ch-topics">Build a multi-level refresh pipeline that never blocks concurrent reads.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Arrays to reduce row count (array_agg)</span><span class="cp-ch-topics">Collapse per-group rows into arrays to simplify downstream processing.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/data-schema-design/json-and-denormalized-types/">JSONB, Arrays &amp; Ranges</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-f1db-results-erd.svg" alt="Star schema: fact table with dimension tables">
-          <figcaption>A star schema puts the fact table at the center, dimension tables at the edges — aggregation speed comes from pre-joining along dimension foreign keys.</figcaption>
+          <figcaption>See how a star schema organizes fact and dimension tables for fast aggregation.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 05 · Star join revenue</div>
@@ -307,19 +317,20 @@ rollback;</code></pre>
       <p class="cp-part-meta">Core · 6 topics</p>
       <p class="cp-part-desc">Adding NOT NULL columns to large tables, renaming constraints without downtime, and building indexes CONCURRENTLY. The three-step pattern for zero-downtime constraint changes in production.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-6">Chapter 29 — Normalization</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Adding a column without a table rewrite (PostgreSQL 11+)</span><span class="cp-ch-topics">PostgreSQL 11 adds columns with non-volatile defaults without rewriting the heap.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Adding constraints safely</span><span class="cp-ch-topics">NOT VALID skips historical row checks; VALIDATE CONSTRAINT fills the gap later.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Building indexes without downtime</span><span class="cp-ch-topics">CREATE INDEX CONCURRENTLY builds the index live without blocking reads or writes.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Production role hierarchy</span><span class="cp-ch-topics">Three-role hierarchy separates admin, schema owner, and application credentials by least privilege.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Three-step pattern: add column → backfill → enforce NOT NULL</span><span class="cp-ch-topics">The three-step migration adds the column nullable, backfills, then enforces NOT NULL.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Rolling back schema deployments</span><span class="cp-ch-topics">Deploying schema changes before code lets each step roll back independently.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Adding a column without a table rewrite (PostgreSQL 11+)</span><span class="cp-ch-topics">Add columns with defaults to large tables without triggering a table rewrite.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Adding constraints safely</span><span class="cp-ch-topics">Add a constraint to a live table without locking out concurrent writes.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Building indexes without downtime</span><span class="cp-ch-topics">Build a new index on a production table without taking it offline.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Production role hierarchy</span><span class="cp-ch-topics">Design a role hierarchy that limits each credential to its minimum needed access.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Three-step pattern: add column → backfill → enforce NOT NULL</span><span class="cp-ch-topics">Execute a zero-downtime NOT NULL migration across add, backfill, and enforce steps.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Rolling back schema deployments</span><span class="cp-ch-topics">Structure schema deployments so each step can be rolled back independently.</span></div></div>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-io-patterns.svg" alt="I/O patterns for safe schema changes">
-          <figcaption>CREATE INDEX CONCURRENTLY and NOT VALID + VALIDATE CONSTRAINT each avoid a full table lock — background work replaces a single blocking scan.</figcaption>
+          <figcaption>See how background builds replace single blocking scans for indexes and constraints.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 06 · NOT VALID constraint</div>
@@ -366,17 +377,19 @@ rollback;</code></pre>
       <p class="cp-part-meta">Advanced · 4 topics</p>
       <p class="cp-part-desc">EAV vs JSONB vs typed columns — when each wins and what you give up. Exclusion constraints for temporal non-overlap, trigram indexes for fuzzy search, and audit trail patterns.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-6">Chapter 32 — Denormalization</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">The EAV anti-pattern and JSONB as a replacement</span><span class="cp-ch-topics">EAV attributes-as-rows makes joins expensive; JSONB stores them in a single column.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Normalising free-text fields: trigram similarity and many-to-many schema</span><span class="cp-ch-topics">Trigram similarity clusters variant composer spellings into a canonical many-to-many schema.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Modeling band membership with tstzrange exclusion constraints</span><span class="cp-ch-topics">tstzrange exclusion constraints prevent overlapping membership windows even under concurrent writes.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Multirange variant (tstzmultirange) for multiple stint windows</span><span class="cp-ch-topics">tstzmultirange stores multiple non-overlapping periods in one column, simplifying range queries.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">The EAV anti-pattern and JSONB as a replacement</span><span class="cp-ch-topics">Recognise when the EAV pattern creates performance and maintainability problems.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Normalising free-text fields: trigram similarity and many-to-many schema</span><span class="cp-ch-topics">Normalise free-text fields by clustering similar spellings into a canonical form.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Modeling band membership with tstzrange exclusion constraints</span><span class="cp-ch-topics">Model non-overlapping time periods and enforce them at the database level.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Multirange variant (tstzmultirange) for multiple stint windows</span><span class="cp-ch-topics">Represent multiple time periods per entity in a single queryable column.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/data-schema-design/json-and-denormalized-types/">JSONB, Arrays &amp; Ranges</a> · <a href="/yesql/data-schema-design/range-types/">Range Types &amp; Temporal Constraints</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-eav-antipattern.svg" alt="EAV anti-pattern vs JSONB">
-          <figcaption>The EAV anti-pattern stores every attribute as a row — JSONB flattens the same flexibility into a single typed column, enabling indexes and operators that EAV cannot support.</figcaption>
+          <figcaption>Compare EAV and JSONB approaches for storing flexible attribute sets.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 07 · Trigram similarity</div>
@@ -421,20 +434,22 @@ select k.artist          as known_artist,
       <p class="cp-part-meta">Architect · 7 topics</p>
       <p class="cp-part-desc">Schema design as a systems concern — separation of concerns between schemas, multi-tenant patterns, audit log strategies, and how schema choices cascade into application architecture and scaling decisions.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-6">Chapter 32 — Denormalization</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">JSONB document model vs relational model</span><span class="cp-ch-topics">JSONB bridges document and relational models by storing objects with SQL-accessible structure.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Querying JSONB: -&gt;, -&gt;&gt;, #&gt;, path operators, @?, @@</span><span class="cp-ch-topics">Arrow operators extract values; path operators and @? query nested JSONB fields.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Containment with GIN index (@&gt;)</span><span class="cp-ch-topics">GIN on JSONB accelerates @&gt; containment checks without scanning every row.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">JSONB as an audit trail (to_jsonb + trigger)</span><span class="cp-ch-topics">Triggers and to_jsonb snapshot row state into an append-only JSONB audit log.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Building and decomposing JSONB (jsonb_build_object, jsonb_agg)</span><span class="cp-ch-topics">jsonb_build_object constructs JSONB from scalars; jsonb_agg aggregates rows into a JSONB array.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">SQL/JSON path language (PostgreSQL 12+)</span><span class="cp-ch-topics">SQL/JSON path expressions navigate nested JSONB documents with a compact standard syntax.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">07</span><div><span class="cp-ch-title">Expression index on extracted JSONB fields</span><span class="cp-ch-topics">Indexing a JSONB -&gt;&gt; expression makes field lookups as fast as columns.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">JSONB document model vs relational model</span><span class="cp-ch-topics">Decide when a document model fits better than a fully normalised relational schema.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Querying JSONB: -&gt;, -&gt;&gt;, #&gt;, path operators, @?, @@</span><span class="cp-ch-topics">Query deeply nested JSONB documents using PostgreSQL path operators.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Containment with GIN index (@&gt;)</span><span class="cp-ch-topics">Index JSONB columns so containment queries run without full-table scans.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">JSONB as an audit trail (to_jsonb + trigger)</span><span class="cp-ch-topics">Build an append-only audit trail that captures full row snapshots automatically.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Building and decomposing JSONB (jsonb_build_object, jsonb_agg)</span><span class="cp-ch-topics">Construct and aggregate JSONB documents directly from relational query results.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">SQL/JSON path language (PostgreSQL 12+)</span><span class="cp-ch-topics">Navigate nested JSONB documents using standard SQL/JSON path expressions.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">07</span><div><span class="cp-ch-title">Expression index on extracted JSONB fields</span><span class="cp-ch-topics">Make specific JSONB field lookups as fast as querying a regular column.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/data-schema-design/json-and-denormalized-types/">JSONB, Arrays &amp; Ranges</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-document-vs-relational.svg" alt="Document model vs relational model">
-          <figcaption>A document model stores the full object in one row; the relational model normalizes it across tables — JSONB bridges both with relational operators on the document.</figcaption>
+          <figcaption>Understand the trade-off between document storage and relational normalisation.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 08 · Materialized view + refresh</div>

--- a/layouts/page/course-query-optimization.html
+++ b/layouts/page/course-query-optimization.html
@@ -70,17 +70,19 @@
       <p class="cp-part-meta">Core · 4 topics</p>
       <p class="cp-part-desc">The planner generates a plan tree from statistics and cost estimates. This module covers pg_stats, row-count estimates, join ordering, and how cost model parameters shape planning decisions.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Cost model settings (seq_page_cost, random_page_cost)</span><span class="cp-ch-topics">seq_page_cost and random_page_cost calibrate I/O cost weights for every plan decision.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Table statistics</span><span class="cp-ch-topics">pg_stats exposes MCVs, histograms, and null fraction used for row-count estimates.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Row estimates from EXPLAIN</span><span class="cp-ch-topics">EXPLAIN rows=N shows the planner's estimate, derived from column statistics before execution.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Query lifecycle statistics with pg_stat_statements</span><span class="cp-ch-topics">pg_stat_statements accumulates call counts and total execution time per normalized query shape.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Cost model settings (seq_page_cost, random_page_cost)</span><span class="cp-ch-topics">Tune cost model settings to match your server's actual storage performance.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Table statistics</span><span class="cp-ch-topics">Understand how PostgreSQL estimates row counts before a query runs.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Row estimates from EXPLAIN</span><span class="cp-ch-topics">Spot row-count estimates in query plans and trace them back to statistics.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Query lifecycle statistics with pg_stat_statements</span><span class="cp-ch-topics">Find which queries consume the most cumulative time in your database.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/reading-explain/">Reading EXPLAIN</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-query-pipeline.svg" alt="Query execution pipeline">
-          <figcaption>A query travels from parse tree through rewriter and planner to executor — statistics and cost estimates drive every planning decision</figcaption>
+          <figcaption>Trace the path a query takes from parsing to execution.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 01 · Cost model parameters</div>
@@ -114,17 +116,19 @@
       <p class="cp-part-meta">Core · 4 topics</p>
       <p class="cp-part-desc">EXPLAIN reveals startup cost, total cost, estimated rows, and row width for every node. FORMAT JSON and the indentation model are covered alongside how to read a multi-node plan tree.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Basic EXPLAIN</span><span class="cp-ch-topics">EXPLAIN shows cost, estimated rows, and row width for every plan node.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">EXPLAIN ANALYZE</span><span class="cp-ch-topics">ANALYZE adds actual row counts and timing alongside the planner's estimates.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">BUFFERS</span><span class="cp-ch-topics">BUFFERS adds cache hit and disk read counts at every plan node.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Plan node types: Seq Scan, Index Scan, Hash Join, Nested Loop, Merge Join</span><span class="cp-ch-topics">Each plan node type has a characteristic cost and scaling profile.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Basic EXPLAIN</span><span class="cp-ch-topics">Read cost and row estimates for every step of a query plan.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">EXPLAIN ANALYZE</span><span class="cp-ch-topics">Compare estimated vs. actual rows to catch planner misestimates.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">BUFFERS</span><span class="cp-ch-topics">Identify which plan nodes generate the most disk I/O.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Plan node types: Seq Scan, Index Scan, Hash Join, Nested Loop, Merge Join</span><span class="cp-ch-topics">Recognize scan and join node types and predict how they scale.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/reading-explain/">Reading EXPLAIN</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-explain-anatomy.svg" alt="EXPLAIN anatomy">
-          <figcaption>Every EXPLAIN node reports startup cost, total cost, estimated rows, and row width — four numbers that tell the optimizer's story</figcaption>
+          <figcaption>Read the four key numbers at every plan node.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 02 · EXPLAIN ANALYZE join</div>
@@ -154,17 +158,19 @@ select r.name    as race,
       <p class="cp-part-meta">Core · 4 topics</p>
       <p class="cp-part-desc">pg_stat_statements ranks queries by cumulative total time — the right starting point for any optimization session. EXPLAIN ANALYZE adds actual rows and timing; BUFFERS shows cache hits vs disk reads.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Sequential scan cost on large tables</span><span class="cp-ch-topics">A sequential scan reads every table page; pg_class.relpages determines its base cost.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Misestimation from correlated columns</span><span class="cp-ch-topics">Correlated columns mislead row estimates; CREATE STATISTICS fixes them by recording dependency.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Sort cost</span><span class="cp-ch-topics">An unindexed sort materializes all matching rows before the first result returns.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Join selectivity and predicate ordering</span><span class="cp-ch-topics">Applying the most selective filter first shrinks the join's intermediate row count.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Sequential scan cost on large tables</span><span class="cp-ch-topics">Estimate the cost of a full table scan before running any query.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Misestimation from correlated columns</span><span class="cp-ch-topics">Fix row-count misestimates caused by columns that are not statistically independent.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Sort cost</span><span class="cp-ch-topics">Spot when an unindexed sort is blocking early result delivery.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Join selectivity and predicate ordering</span><span class="cp-ch-topics">Order join predicates to minimize the number of intermediate rows processed.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/reading-explain/">Reading EXPLAIN</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-explain-startup-cost.svg" alt="Estimated vs actual row counts">
-          <figcaption>EXPLAIN ANALYZE shows estimated vs actual row counts — a large divergence signals stale statistics or correlated predicates that the planner's independence assumption misses.</figcaption>
+          <figcaption>Spot estimate divergence and trace it to a statistics problem.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 03 · Correlated column misestimate</div>
@@ -193,17 +199,19 @@ select name, population
       <p class="cp-part-meta">Core · 4 topics</p>
       <p class="cp-part-desc">Predicate pushdown, CTE fences, and subquery flattening change what the planner can see. Restructuring a query to remove barriers often yields more improvement than any index change.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Predicate pushdown</span><span class="cp-ch-topics">Inline predicates let the planner filter rows at the earliest scan node.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">EXISTS vs IN for subqueries</span><span class="cp-ch-topics">EXISTS stops at the first match; IN materializes all matches before proceeding.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">CTE optimization fences</span><span class="cp-ch-topics">MATERIALIZED forces a separate execution step; inlined CTEs are optimized as subqueries.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Removing unnecessary work: DISTINCT, COUNT semantics</span><span class="cp-ch-topics">Eliminating unneeded DISTINCT and misused COUNT semantics removes hidden deduplication passes.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Predicate pushdown</span><span class="cp-ch-topics">Rewrite queries so filters are applied as early as possible.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">EXISTS vs IN for subqueries</span><span class="cp-ch-topics">Choose the right subquery form to avoid unnecessary row materialization.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">CTE optimization fences</span><span class="cp-ch-topics">Control whether a CTE is a planning barrier or a transparent subquery.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Removing unnecessary work: DISTINCT, COUNT semantics</span><span class="cp-ch-topics">Remove hidden deduplication work that adds overhead without changing results.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/query-rewriting/">Query Rewriting &amp; Anti-Patterns</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-plan-tree.svg" alt="Plan tree showing predicate pushdown">
-          <figcaption>Predicate pushdown moves filter conditions as close to the data source as possible — the plan tree shows whether filters are applied at the scan node or wastefully at a higher level.</figcaption>
+          <figcaption>See where filters land in the plan tree.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 04 · Predicate pushdown</div>
@@ -234,16 +242,18 @@ select r.name, r.date,
       <p class="cp-part-meta">Core · 3 topics</p>
       <p class="cp-part-desc">Leading-wildcard LIKE, implicit type coercion, function-wrapped indexed columns, and NOT IN with nullable columns — each prevents index use in ways that are easy to miss in code review.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Non-sargable predicates</span><span class="cp-ch-topics">A function-wrapped column forces a seq scan; an expression index restores it.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">OFFSET pagination vs keyset pagination</span><span class="cp-ch-topics">OFFSET gets more expensive with depth; keyset pagination is always constant cost.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">SELECT * and row width impact</span><span class="cp-ch-topics">Selecting unused columns widens the plan, increasing sort, hash, and network costs.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Non-sargable predicates</span><span class="cp-ch-topics">Spot predicates that silently defeat index use and know how to fix them.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">OFFSET pagination vs keyset pagination</span><span class="cp-ch-topics">Implement pagination that stays fast regardless of which page you request.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">SELECT * and row width impact</span><span class="cp-ch-topics">Limit column selection to what queries actually need.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/query-rewriting/">Query Rewriting &amp; Anti-Patterns</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-btree-page-layout.svg" alt="B-tree and non-sargable predicates">
-          <figcaption>A function on an indexed column (WHERE lower(name) = ...) forces a full Seq Scan — a functional index on lower(name) restores index access without changing the query.</figcaption>
+          <figcaption>See how a predicate form can defeat index access.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 05 · Keyset pagination</div>
@@ -272,20 +282,22 @@ select geonameid, name
       <p class="cp-part-meta">Core · 7 topics</p>
       <p class="cp-part-desc">Partial indexes, covering indexes, expression indexes, and multi-column index column order. Index-only scans eliminate heap access entirely — when they're possible and when the visibility map blocks them.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Index types: B-tree, Hash, GiST, GIN, BRIN</span><span class="cp-ch-topics">B-tree handles ranges and sorting; GiST geometry; GIN arrays; BRIN sequential data.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Selectivity and index choice</span><span class="cp-ch-topics">A highly selective predicate favors an index scan over a sequential scan.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Composite indexes and column order</span><span class="cp-ch-topics">A composite index requires its leading column in WHERE to be usable.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Partial indexes</span><span class="cp-ch-topics">A partial index targets a row subset via WHERE clause, reducing its size.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Covering indexes with INCLUDE clause</span><span class="cp-ch-topics">INCLUDE adds columns to leaf pages so the heap is never fetched.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Index-only scans and the visibility map</span><span class="cp-ch-topics">Index-only scans skip the heap for pages the visibility map marks all-visible.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">07</span><div><span class="cp-ch-title">GiST kNN scan and GIN array containment</span><span class="cp-ch-topics">GiST enables ordered kNN traversal; GIN enables array containment via posting-list intersection.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Index types: B-tree, Hash, GiST, GIN, BRIN</span><span class="cp-ch-topics">Choose the right index type for your data shape and access pattern.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Selectivity and index choice</span><span class="cp-ch-topics">Predict when the planner will choose an index over a full table scan.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Composite indexes and column order</span><span class="cp-ch-topics">Design multi-column indexes that your queries can actually use.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Partial indexes</span><span class="cp-ch-topics">Create indexes that cover only the rows your queries actually filter on.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Covering indexes with INCLUDE clause</span><span class="cp-ch-topics">Build covering indexes that satisfy queries without touching the table.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Index-only scans and the visibility map</span><span class="cp-ch-topics">Understand when a query can be answered entirely from the index.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">07</span><div><span class="cp-ch-title">GiST kNN scan and GIN array containment</span><span class="cp-ch-topics">Index geometric distances and array membership for specialized query patterns.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/indexing-strategy/">Indexing Strategy</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-index-types.svg" alt="Index types">
-          <figcaption>Partial, covering, and expression indexes extend B-tree beyond the basics — the right index can eliminate table access entirely</figcaption>
+          <figcaption>Match the index variant to the query it needs to serve.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 06 · Partial index targeting</div>
@@ -317,16 +329,18 @@ select res.raceid,
       <p class="cp-part-meta">Advanced · 3 topics</p>
       <p class="cp-part-desc">Parallel query configuration, partition pruning, and BRIN for sequential data. This module covers when to reach for pg_hint_plan and when to fix the statistics instead.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Tables and views inventory (pg_class)</span><span class="cp-ch-topics">pg_class exposes each relation's physical size in pages, guiding materialization decisions.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Materialized CTEs (WITH … AS MATERIALIZED)</span><span class="cp-ch-topics">AS MATERIALIZED caches the CTE result once for multiple outer query references.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Query decomposition with named CTEs</span><span class="cp-ch-topics">Named CTEs break complex queries into readable stages without creating optimization fences.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Tables and views inventory (pg_class)</span><span class="cp-ch-topics">Inspect relation sizes to guide caching and materialization decisions.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Materialized CTEs (WITH … AS MATERIALIZED)</span><span class="cp-ch-topics">Cache an intermediate result when the same data is needed multiple times.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Query decomposition with named CTEs</span><span class="cp-ch-topics">Decompose complex queries into readable stages without blocking the optimizer.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/query-rewriting/">Query Rewriting &amp; Anti-Patterns</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-node-types.svg" alt="Parallel plan nodes: Gather and Gather Merge">
-          <figcaption>Gather and Gather Merge nodes mark the boundary between serial and parallel execution — partition pruning eliminates sub-plans at planning time, Gather collects parallel worker results.</figcaption>
+          <figcaption>Identify parallel and partition-aware nodes in a plan tree.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 07 · Career statistics profiling</div>
@@ -365,21 +379,23 @@ select d.surname,
       <p class="cp-part-meta">Architect · 8 topics</p>
       <p class="cp-part-desc">Observe → Diagnose → Fix → Verify: a repeatable cycle for closing the feedback loop on query performance. Performance SLAs, regression guards, and continuous monitoring with pg_stat_statements.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Step 1 — Observe: pg_stat_statements, pg_stat_user_tables</span><span class="cp-ch-topics">pg_stat_statements sorted by total_exec_time gives the optimization backlog in priority order.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Step 2 — Diagnose: plan signals (filter removal, spill, batches, estimate divergence)</span><span class="cp-ch-topics">Filter rows, spills, and estimate divergence each identify a specific plan problem.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Step 3 — Fix: ANALYZE, index creation, query rewrite, work_mem, VACUUM</span><span class="cp-ch-topics">Change one thing at a time: ANALYZE, index, query rewrite, or work_mem.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Step 4 — Verify: plan comparison, pg_stat_statements confirmation</span><span class="cp-ch-topics">After each fix, compare node type, actual timing, and buffer read count.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Partitioning and partition pruning</span><span class="cp-ch-topics">Partition pruning skips non-matching segments when the predicate matches the partition key.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Parallel query: Gather, Gather Merge</span><span class="cp-ch-topics">Gather nodes split large scans across workers; Gather Merge preserves sort order.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">07</span><div><span class="cp-ch-title">Performance budgets, query SLAs, caching ladder</span><span class="cp-ch-topics">Performance budgets allocate latency across layers; SLAs and monitoring catch regressions early.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">08</span><div><span class="cp-ch-title">When not to optimize</span><span class="cp-ch-topics">Amdahl's law limits the gain; stop optimizing once the SLA is satisfied.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Step 1 — Observe: pg_stat_statements, pg_stat_user_tables</span><span class="cp-ch-topics">Build a prioritized list of queries to optimize from real runtime data.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Step 2 — Diagnose: plan signals (filter removal, spill, batches, estimate divergence)</span><span class="cp-ch-topics">Read plan warning signals and link each one to a specific root cause.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Step 3 — Fix: ANALYZE, index creation, query rewrite, work_mem, VACUUM</span><span class="cp-ch-topics">Apply one targeted fix at a time and measure its effect before continuing.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Step 4 — Verify: plan comparison, pg_stat_statements confirmation</span><span class="cp-ch-topics">Confirm each optimization actually improved the plan before moving on.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Partitioning and partition pruning</span><span class="cp-ch-topics">Leverage table partitioning to skip irrelevant data at planning time.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Parallel query: Gather, Gather Merge</span><span class="cp-ch-topics">Enable parallel execution for large scans and understand how results are merged.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">07</span><div><span class="cp-ch-title">Performance budgets, query SLAs, caching ladder</span><span class="cp-ch-topics">Set performance targets per query and detect regressions before they reach users.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">08</span><div><span class="cp-ch-title">When not to optimize</span><span class="cp-ch-topics">Know when a query is good enough and when to stop optimizing.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/reading-explain/">Reading EXPLAIN</a> · <a href="/yesql/performance/query-rewriting/">Query Rewriting &amp; Anti-Patterns</a> · <a href="/yesql/performance/indexing-strategy/">Indexing Strategy</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-optimization-workflow.svg" alt="Optimization workflow">
-          <figcaption>Observe → Diagnose → Fix → Verify: one targeted change per cycle, confirmed before moving on to the next query</figcaption>
+          <figcaption>Follow each step of a repeatable optimization cycle.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 08 · Partition inventory</div>

--- a/layouts/page/course-read-query-plans.html
+++ b/layouts/page/course-read-query-plans.html
@@ -70,18 +70,20 @@
       <p class="cp-part-meta">Core · 5 topics</p>
       <p class="cp-part-desc">The EXPLAIN output reports five numbers per node: startup cost, total cost, estimated rows, row width, and — with ANALYZE — actual timing. This module teaches you to read those numbers and locate the bottleneck node.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Basic EXPLAIN syntax</span><span class="cp-ch-topics">A single-table EXPLAIN yields one Seq Scan with cost, rows, and width.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Plan tree structure</span><span class="cp-ch-topics">Indentation shows the tree: leaf nodes are scans, parent nodes are joins.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Cost anatomy: startup vs total cost</span><span class="cp-ch-topics">High startup cost signals work done before the first row is returned.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Sequential Scan node and the Filter annotation</span><span class="cp-ch-topics">Rows Removed by Filter on a Seq Scan signals a missing index.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">EXPLAIN options: VERBOSE, SETTINGS, WAL, GENERIC_PLAN</span><span class="cp-ch-topics">VERBOSE prints each node's output columns; SETTINGS reveals non-default planner parameters.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Basic EXPLAIN syntax</span><span class="cp-ch-topics">Run EXPLAIN on a query and read the plan output it produces.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Plan tree structure</span><span class="cp-ch-topics">Navigate the plan tree structure by reading node indentation.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Cost anatomy: startup vs total cost</span><span class="cp-ch-topics">Distinguish startup cost from total cost and explain the difference.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Sequential Scan node and the Filter annotation</span><span class="cp-ch-topics">Spot filter annotations that signal missing index opportunities.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">EXPLAIN options: VERBOSE, SETTINGS, WAL, GENERIC_PLAN</span><span class="cp-ch-topics">Use EXPLAIN options to expose extra plan detail when needed.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/reading-explain/">Reading EXPLAIN</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-explain-anatomy.svg" alt="EXPLAIN output anatomy">
-          <figcaption>Every EXPLAIN line reports five numbers — once you know where each lives, the plan tree is readable in seconds.</figcaption>
+          <figcaption>Identify and locate each cost number in an EXPLAIN line.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 01 · Startup vs total cost</div>
@@ -112,18 +114,20 @@ select d.surname,
       <p class="cp-part-meta">Core · 5 topics</p>
       <p class="cp-part-desc">EXPLAIN ANALYZE runs the query and adds actual rows, actual time, and loop counts. The gap between estimated and actual rows is the key signal — it tells you where the planner's model breaks down.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Actual timing and row counts (actual time, actual rows, loops)</span><span class="cp-ch-topics">ANALYZE adds measured milliseconds and actual row counts to each plan node.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Running EXPLAIN ANALYZE safely</span><span class="cp-ch-topics">Wrap data-modifying statements in BEGIN/ROLLBACK to measure without committing changes.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Actual vs estimated row divergence</span><span class="cp-ch-topics">Where estimated and actual rows diverge, the planner relied on wrong statistics.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Loops</span><span class="cp-ch-topics">Inner-side rows and timing shown are per-loop averages, not totals.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">BUFFERS: shared hit vs read; track_io_timing</span><span class="cp-ch-topics">Shared hits come from buffer cache; shared reads come from disk.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Actual timing and row counts (actual time, actual rows, loops)</span><span class="cp-ch-topics">Add actual timing and row counts to any EXPLAIN output.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Running EXPLAIN ANALYZE safely</span><span class="cp-ch-topics">Safely measure write queries without committing unwanted changes.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Actual vs estimated row divergence</span><span class="cp-ch-topics">Identify where the planner's row estimates diverge from reality.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Loops</span><span class="cp-ch-topics">Correctly interpret row counts and timing in looping plan nodes.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">BUFFERS: shared hit vs read; track_io_timing</span><span class="cp-ch-topics">Distinguish cache hits from disk reads in BUFFERS output.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/reading-explain/">Reading EXPLAIN</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-explain-startup-cost.svg" alt="EXPLAIN ANALYZE actual vs estimated rows">
-          <figcaption>ANALYZE adds actual row counts and timing — the gap between estimated and actual rows is the key diagnostic signal.</figcaption>
+          <figcaption>Spot the gap between estimated and actual row counts.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 02 · Estimated vs actual rows</div>
@@ -152,19 +156,21 @@ select r.year,
       <p class="cp-part-meta">Core · 6 topics</p>
       <p class="cp-part-desc">Sequential Scan, Index Scan, Index Only Scan, Bitmap Heap Scan, Hash Join, Merge Join, Nested Loop, Hash Aggregate, and Sort — what each node does, when it appears, and what its cost shape looks like.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Scan nodes: Seq Scan, Index Scan, Index Only Scan, Bitmap Heap Scan, CTE Scan</span><span class="cp-ch-topics">Scan leaves read from the heap, an index, or a materialized tuplestore.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">GiST Index Scan: Order By vs Index Cond in kNN mode</span><span class="cp-ch-topics">GiST kNN: tree traversal in distance order eliminates the Sort node.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Join nodes: Hash Join, Nested Loop (Memoize), Merge Join</span><span class="cp-ch-topics">Hash Join, Nested Loop, and Merge Join each suit different cardinality regimes.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Aggregation and sort: Sort, Incremental Sort, HashAggregate, WindowAgg</span><span class="cp-ch-topics">Sort materializes all input first; Incremental Sort batches by presorted prefix keys.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Set operation nodes: Append (UNION ALL), Recursive Union</span><span class="cp-ch-topics">Append sequences sub-plans without deduplication; Recursive Union iterates until no new rows.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Parallel nodes: Gather, Gather Merge</span><span class="cp-ch-topics">Gather collects worker output; Gather Merge also preserves global sort order.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Scan nodes: Seq Scan, Index Scan, Index Only Scan, Bitmap Heap Scan, CTE Scan</span><span class="cp-ch-topics">Recognize each scan node type and when it appears.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">GiST Index Scan: Order By vs Index Cond in kNN mode</span><span class="cp-ch-topics">Read GiST index scan plans for nearest-neighbor queries.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Join nodes: Hash Join, Nested Loop (Memoize), Merge Join</span><span class="cp-ch-topics">Identify which join algorithm appears and why the planner chose it.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Aggregation and sort: Sort, Incremental Sort, HashAggregate, WindowAgg</span><span class="cp-ch-topics">Distinguish Sort from Incremental Sort and understand the cost difference.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Set operation nodes: Append (UNION ALL), Recursive Union</span><span class="cp-ch-topics">Read plans for UNION ALL queries and recursive CTEs.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Parallel nodes: Gather, Gather Merge</span><span class="cp-ch-topics">Understand parallel plan structure and locate worker sub-plans.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/reading-explain/">Reading EXPLAIN</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-node-types.svg" alt="Plan node types">
-          <figcaption>Seq Scan, Index Scan, Bitmap Scan, Hash Join, Merge Join, Hash Aggregate — each node has a distinct cost shape and appears under specific conditions.</figcaption>
+          <figcaption>Match each node type to its typical cost shape.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 03 · Hash Join node</div>
@@ -199,17 +205,19 @@ select d.nationality,
       <p class="cp-part-meta">Core · 4 topics</p>
       <p class="cp-part-desc">Batches &gt; 1 on a HashJoin means the hash table spilled to disk. Sort Method: external merge means the sort did too. Rows × loops mismatches point to bad estimates compounding through the tree.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Row estimate mismatch</span><span class="cp-ch-topics">Row estimate errors propagate upward, causing wrong join algorithms and memory sizing.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Expensive Sort</span><span class="cp-ch-topics">Startup cost near total cost means the Sort materializes all input first.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Hash Join batches</span><span class="cp-ch-topics">Batches greater than one means the hash table overflowed work_mem to disk.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Rows Removed by Filter</span><span class="cp-ch-topics">High fetch-then-discard ratio on a Seq Scan points to a missing index.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Row estimate mismatch</span><span class="cp-ch-topics">Trace how a single bad estimate degrades the entire plan.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Expensive Sort</span><span class="cp-ch-topics">Recognize when a Sort node is the plan's bottleneck.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Hash Join batches</span><span class="cp-ch-topics">Detect when a Hash Join spills to disk and why.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Rows Removed by Filter</span><span class="cp-ch-topics">Use filter row counts to identify missing index candidates.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/reading-explain/">Reading EXPLAIN</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-plan-tree.svg" alt="Plan tree structure">
-          <figcaption>The plan tree shows which operations feed into which — reading leaves to root follows the actual execution order.</figcaption>
+          <figcaption>Follow execution order from leaf nodes up to the root.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 04 · Row estimate mismatch</div>
@@ -240,16 +248,18 @@ select res.raceid,
       <p class="cp-part-meta">Core · 3 topics</p>
       <p class="cp-part-desc">A structured plan-reading session: find the most expensive node, check its estimate vs actual, identify the root cause (missing index, stale statistics, type mismatch), apply the targeted fix.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Index recommendations from Seq Scan + Filter signals</span><span class="cp-ch-topics">Rows Removed by Filter on a Seq Scan identifies missing index candidates.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Join rewrite: pushing predicates into JOIN ON for earlier filtering</span><span class="cp-ch-topics">JOIN ON predicates apply at the scan level, reducing intermediate result sizes.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Cost-based decisions: reading planner cost numbers</span><span class="cp-ch-topics">EXPLAIN cost numbers reveal which alternative the planner found cheaper and why.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Index recommendations from Seq Scan + Filter signals</span><span class="cp-ch-topics">Spot index opportunities from plan filter annotations.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Join rewrite: pushing predicates into JOIN ON for earlier filtering</span><span class="cp-ch-topics">Rewrite queries to push predicates earlier and reduce plan cost.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Cost-based decisions: reading planner cost numbers</span><span class="cp-ch-topics">Compare plan costs to understand the planner's optimization choices.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/reading-explain/">Reading EXPLAIN</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-cost-model.svg" alt="Cost model and estimate propagation">
-          <figcaption>A row estimate error at one node propagates up the tree — the planner multiplies selectivities independently, so correlated columns produce compounding underestimates.</figcaption>
+          <figcaption>See how estimate errors compound through the plan tree.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 05 · Inlined predicate</div>
@@ -285,18 +295,20 @@ select d.surname,
       <p class="cp-part-meta">Core · 5 topics</p>
       <p class="cp-part-desc">FORMAT JSON for tooling integration, EXPLAIN BUFFERS for cache analysis, and pev2 / explain.depesz.com for complex plans. Parallel gather nodes and how to read the worker sub-plans they coordinate.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Bitmap Index Scan</span><span class="cp-ch-topics">Bitmap scan fetches matching heap pages in physical order, avoiding random I/O.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">GIN Bitmap Heap Scan for array containment</span><span class="cp-ch-topics">GIN builds the bitmap by intersecting one posting list per array element.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Subplan nodes: InitPlan, SubPlan</span><span class="cp-ch-topics">Rewriting a correlated subquery as a join eliminates per-row SubPlan executions.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">CTE Scan node</span><span class="cp-ch-topics">CTE Scan reads a tuplestore populated once by the CTE's single execution.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Window function plans</span><span class="cp-ch-topics">WindowAgg materializes all partition rows before returning any window function result.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Bitmap Index Scan</span><span class="cp-ch-topics">Read Bitmap Scan plans and understand when they appear.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">GIN Bitmap Heap Scan for array containment</span><span class="cp-ch-topics">Interpret GIN index plans for array containment queries.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Subplan nodes: InitPlan, SubPlan</span><span class="cp-ch-topics">Recognize costly SubPlan nodes and know when to rewrite them.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">CTE Scan node</span><span class="cp-ch-topics">Understand how CTE Scan nodes appear in plan output.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Window function plans</span><span class="cp-ch-topics">Read EXPLAIN plans for window queries and identify each node's role.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/reading-explain/">Reading EXPLAIN</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-plan-tree-join.svg" alt="Complex plan tree with join nodes">
-          <figcaption>Memoize sits between a Nested Loop and its inner-side Index Scan — it caches the most recent probe result, eliminating redundant lookups when the join key repeats.</figcaption>
+          <figcaption>Locate Memoize nodes that cache repeated inner-side lookups.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 06 · WindowAgg plan node</div>
@@ -335,17 +347,19 @@ select r.year,
       <p class="cp-part-meta">Advanced · 4 topics</p>
       <p class="cp-part-desc">pg_stat_activity for live query monitoring, lock monitoring with pg_locks, and CREATE STATISTICS for correlated columns. How to triage a slow-query incident without disturbing production traffic.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Diagnostic step 1: scan ratios from pg_stat_user_tables</span><span class="cp-ch-topics">High seq_scan and low idx_scan ratios identify tables missing useful indexes.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Diagnostic step 2: plan comparison</span><span class="cp-ch-topics">Compare EXPLAIN ANALYZE output before and after a change to verify improvement.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Machine-readable plans with FORMAT JSON (explain.depesz.com, pev2)</span><span class="cp-ch-topics">FORMAT JSON outputs machine-readable plans for external visualization tools like pev2.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Repeatable benchmarking</span><span class="cp-ch-topics">First runs reflect cold cache; subsequent runs show the stable warm-cache performance.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Diagnostic step 1: scan ratios from pg_stat_user_tables</span><span class="cp-ch-topics">Query pg_stat_user_tables to find tables lacking effective indexes.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Diagnostic step 2: plan comparison</span><span class="cp-ch-topics">Compare plans before and after a change to confirm improvement.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Machine-readable plans with FORMAT JSON (explain.depesz.com, pev2)</span><span class="cp-ch-topics">Export plans in JSON format for use with visualization tools.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Repeatable benchmarking</span><span class="cp-ch-topics">Run repeatable benchmarks that account for cache warming effects.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/reading-explain/">Reading EXPLAIN</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-optimization-workflow.svg" alt="Systematic diagnostic workflow">
-          <figcaption>Live monitoring connects plan-level signals (high startup cost, hash spill) to system-level causes (lock contention, stale statistics) — the diagnostic workflow moves from symptom to root cause.</figcaption>
+          <figcaption>Connect plan signals to system-level root causes systematically.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 07 · Baseline plan comparison</div>
@@ -381,19 +395,21 @@ select d.surname,
       <p class="cp-part-meta">Architect · 6 topics</p>
       <p class="cp-part-desc">VACUUM signals in EXPLAIN output, autovacuum tuning, and pg_stat_user_tables for table-level health. Connecting plan-level observation to database-wide performance management.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-3">Chapter 9 — Indexing Strategy</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Currently running queries: pg_stat_activity (state, wait_event, query)</span><span class="cp-ch-topics">pg_stat_activity shows each session's current state, wait event, and query text.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Table bloat and VACUUM</span><span class="cp-ch-topics">Dead tuples inflate page counts; VACUUM reclaims them and improves scan efficiency.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Lock monitoring</span><span class="cp-ch-topics">Lock contention makes fast plans run slowly; identify blocked and blocking sessions.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Statistics management: pg_stats, default_statistics_target, CREATE STATISTICS</span><span class="cp-ch-topics">Column statistics in pg_stats drive every row estimate in every plan.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Planner limitations: join search space, independence assumption, generic plans</span><span class="cp-ch-topics">Join reordering stops at join_collapse_limit; correlated columns violate the independence assumption.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Chinook: confident inner-join cardinality with enforced foreign keys</span><span class="cp-ch-topics">Enforced FKs give the planner join-cardinality precision unavailable in unconstrained schemas.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Currently running queries: pg_stat_activity (state, wait_event, query)</span><span class="cp-ch-topics">Monitor live queries and identify wait events using system views.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Table bloat and VACUUM</span><span class="cp-ch-topics">Detect table bloat and understand its effect on plan performance.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Lock monitoring</span><span class="cp-ch-topics">Identify lock contention that slows otherwise efficient queries.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Statistics management: pg_stats, default_statistics_target, CREATE STATISTICS</span><span class="cp-ch-topics">Manage column statistics to improve planner row estimates.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Planner limitations: join search space, independence assumption, generic plans</span><span class="cp-ch-topics">Recognize planner limitations that cause systematic misestimates.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">06</span><div><span class="cp-ch-title">Chinook: confident inner-join cardinality with enforced foreign keys</span><span class="cp-ch-topics">Understand how schema constraints affect the planner's join decisions.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/reading-explain/">Reading EXPLAIN</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-io-patterns.svg" alt="I/O patterns and table bloat">
-          <figcaption>Table bloat forces reads through dead tuples — autovacuum signals in pg_stat_user_tables (n_dead_tup, last_autovacuum) connect plan-level degradation to physical storage health.</figcaption>
+          <figcaption>Link plan-level degradation to physical table health metrics.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 08 · chinook FK-enforced plan</div>

--- a/layouts/page/course-window-functions.html
+++ b/layouts/page/course-window-functions.html
@@ -69,18 +69,20 @@
       <p class="cp-part-meta">Core · 5 topics</p>
       <p class="cp-part-desc">Window functions compute a value for each row using a set of related rows, without collapsing them. The OVER clause turns any aggregate into a window function; PARTITION BY divides the window into independent groups.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 18 — Understanding Window Functions</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">OVER clause</span><span class="cp-ch-topics">The OVER clause defines a window of rows over which an aggregate is computed without collapsing the result set.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">ORDER BY within a window</span><span class="cp-ch-topics">ORDER BY defines the row sequence within each partition for ordering-dependent functions like LAG or running totals.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">PARTITION BY</span><span class="cp-ch-topics">PARTITION BY divides rows into independent groups and applies the window function separately within each.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Difference with GROUP BY</span><span class="cp-ch-topics">GROUP BY collapses rows to one per group; window functions add computed columns while preserving every row.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Row vs window context</span><span class="cp-ch-topics">A window context lets each row access values from other rows in its partition, unlike isolated row-level SQL expressions.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">OVER clause</span><span class="cp-ch-topics">Write aggregate expressions that return a value per row instead of per group.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">ORDER BY within a window</span><span class="cp-ch-topics">Control the row sequence inside a window for order-sensitive calculations.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">PARTITION BY</span><span class="cp-ch-topics">Split a dataset into independent groups for per-group window calculations.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Difference with GROUP BY</span><span class="cp-ch-topics">Choose the right tool when you need group context without losing individual rows.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Row vs window context</span><span class="cp-ch-topics">Access values from neighboring rows in the same group without a self-join.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/window-functions/over-clause-mental-model/">The OVER Clause</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-groupby-vs-window.svg" alt="GROUP BY vs Window Functions">
-          <figcaption>GROUP BY collapses rows into groups; PARTITION BY adds a computed column while keeping every row</figcaption>
+          <figcaption>Understand when to keep all rows versus collapse them into a single group result.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 01 · LAG for time gap</div>
@@ -111,17 +113,19 @@
       <p class="cp-part-meta">Core · 4 topics</p>
       <p class="cp-part-desc">ROW_NUMBER, RANK, and DENSE_RANK assign positions within an ordered partition — differing only in how they handle ties. LEAD and LAG navigate to adjacent rows without a self-join.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 18 — Understanding Window Functions</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">ROW_NUMBER</span><span class="cp-ch-topics">ROW_NUMBER assigns a unique sequential integer to each row within its partition with no ties.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">RANK &amp; DENSE_RANK</span><span class="cp-ch-topics">RANK leaves gaps after tied values; DENSE_RANK preserves ties while keeping the sequence continuous.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">NTILE</span><span class="cp-ch-topics">NTILE distributes rows into a fixed number of equal-sized buckets based on their ordering.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">LEAD &amp; LAG</span><span class="cp-ch-topics">LAG and LEAD access the previous or next row's value within a partition without a self-join.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">ROW_NUMBER</span><span class="cp-ch-topics">Assign a unique sequential position to each row within a group.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">RANK &amp; DENSE_RANK</span><span class="cp-ch-topics">Handle tied values with gapped or continuous rank sequences.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">NTILE</span><span class="cp-ch-topics">Divide ordered rows into equal-sized buckets for percentile-style grouping.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">LEAD &amp; LAG</span><span class="cp-ch-topics">Compare each row to its predecessor or successor without a self-join.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/window-functions/row-number-rank-dense-rank/">ROW_NUMBER, RANK, DENSE_RANK</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-window-frame.svg" alt="Window partition and order structure">
-          <figcaption>Every ranking function sees a sorted partition — PARTITION BY divides rows into groups, ORDER BY determines rank position within each.</figcaption>
+          <figcaption>See how ordering and grouping together determine each row's rank position.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 02 · RANK vs DENSE_RANK</div>
@@ -153,16 +157,18 @@
       <p class="cp-part-meta">Core · 3 topics</p>
       <p class="cp-part-desc">SUM() OVER(ORDER BY) produces a running total; add a ROWS N PRECEDING frame and it becomes a moving window. The default frame changes when ORDER BY is present.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 18 — Understanding Window Functions</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">SUM() OVER</span><span class="cp-ch-topics">SUM() OVER with ORDER BY produces a running total that accumulates row by row through the partition.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Moving averages</span><span class="cp-ch-topics">A moving average aggregates a fixed-width sliding band of rows, smoothing fluctuations across the ordered dataset.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Frame clauses: ROWS vs RANGE</span><span class="cp-ch-topics">ROWS counts physical positions; RANGE includes all rows whose ordering value falls within the specified interval.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">SUM() OVER</span><span class="cp-ch-topics">Build a cumulative total that grows row by row through an ordered dataset.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Moving averages</span><span class="cp-ch-topics">Smooth noisy time-series data with a sliding fixed-width aggregate.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Frame clauses: ROWS vs RANGE</span><span class="cp-ch-topics">Choose the right aggregation boundary for physical positions versus value ranges.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/window-functions/running-totals/">Running Totals &amp; Moving Averages</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-range-band-timeline.svg" alt="Moving window on a timeline">
-          <figcaption>A moving average is a window that slides along the timeline — each position aggregates a fixed-width band of preceding rows.</figcaption>
+          <figcaption>See how a sliding window covers a fixed band of rows at each position.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 03 · Running total</div>
@@ -189,18 +195,20 @@
       <p class="cp-part-meta">Core · 5 topics</p>
       <p class="cp-part-desc">ROWS, RANGE, and GROUPS each define which rows enter the frame relative to the current row. Subtle differences emerge with duplicate values, and EXCLUDE lets you remove specific rows from the frame.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 18 — Understanding Window Functions</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">UNBOUNDED PRECEDING &amp; FOLLOWING</span><span class="cp-ch-topics">UNBOUNDED PRECEDING and FOLLOWING extend the frame to the first or last row of the partition.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">CURRENT ROW</span><span class="cp-ch-topics">CURRENT ROW anchors the frame to the row being evaluated, setting one boundary of the window at the current position.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Frame definitions</span><span class="cp-ch-topics">Frame definitions combine ROWS, RANGE, or GROUPS mode with boundary keywords to control which rows each computation sees.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Frame edge cases with duplicate values</span><span class="cp-ch-topics">Duplicate ordering values cause ROWS and RANGE frames to diverge, since ROWS counts positions while RANGE groups peers.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">EXCLUDE clause</span><span class="cp-ch-topics">EXCLUDE removes the current row, its peer group, or just the ties from the frame for everyone-but-me aggregates.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">UNBOUNDED PRECEDING &amp; FOLLOWING</span><span class="cp-ch-topics">Extend a frame to the very first or last row of a partition.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">CURRENT ROW</span><span class="cp-ch-topics">Anchor one frame boundary at the row currently being evaluated.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Frame definitions</span><span class="cp-ch-topics">Combine frame mode and boundaries to control exactly which rows a function sees.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Frame edge cases with duplicate values</span><span class="cp-ch-topics">Anticipate how duplicate ordering values affect which rows enter the frame.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">EXCLUDE clause</span><span class="cp-ch-topics">Exclude specific rows from the frame for self-excluding aggregates.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/window-functions/frame-semantics/">Frame Semantics</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-window-frame-spec.svg" alt="Window frame specification">
-          <figcaption>Frame boundaries define exactly which rows each function sees relative to the current row</figcaption>
+          <figcaption>Understand which rows fall inside a frame relative to the current position.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 04 · ROWS vs RANGE</div>
@@ -235,17 +243,19 @@ window
       <p class="cp-part-meta">Core · 4 topics</p>
       <p class="cp-part-desc">Sessionization, gaps &amp; islands, and cohort analysis are classic time-series patterns. Window functions solve them in pure SQL using the running-SUM trick — no procedural loops.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 18 — Understanding Window Functions</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Gaps &amp; islands</span><span class="cp-ch-topics">Gaps and islands patterns detect contiguous sequences or breaks by comparing each row to its predecessor with LAG.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Cohort analysis with FIRST_VALUE()</span><span class="cp-ch-topics">FIRST_VALUE anchors each cohort to its debut measurement, enabling retention and lifecycle metrics across periods.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Sessionization</span><span class="cp-ch-topics">Sessionization assigns group identifiers by summing outlier flags with a running SUM, turning gap detection into session numbers.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Percentiles: PERCENT_RANK, CUME_DIST, NTILE</span><span class="cp-ch-topics">PERCENT_RANK, CUME_DIST, and NTILE express each row's position within its partition as a fraction or bucket number.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Gaps &amp; islands</span><span class="cp-ch-topics">Detect contiguous sequences and breaks in ordered event data.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Cohort analysis with FIRST_VALUE()</span><span class="cp-ch-topics">Anchor each cohort to its first measurement for retention and lifecycle analysis.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Sessionization</span><span class="cp-ch-topics">Group consecutive events into sessions using only pure SQL aggregation.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Percentiles: PERCENT_RANK, CUME_DIST, NTILE</span><span class="cp-ch-topics">Express each row's relative standing as a percentile or bucket within its group.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/window-functions/sessionization/">Sessionization</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-multirange-career.svg" alt="Session gaps on a timeline">
-          <figcaption>Sessionization groups consecutive events by detecting gaps — the running-SUM trick turns an outlier flag into a session number without procedural loops.</figcaption>
+          <figcaption>See how consecutive events are grouped into sessions by detecting time gaps.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 05 · Sessionization</div>
@@ -293,17 +303,19 @@ select surname, stint,
       <p class="cp-part-meta">Core · 4 topics</p>
       <p class="cp-part-desc">Every window query sorts its data and produces a WindowAgg node in EXPLAIN. This module covers sorting cost, spec sharing across multiple windows, and anti-patterns that force unwanted re-scans.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 18 — Understanding Window Functions</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Execution plans and the WindowAgg node</span><span class="cp-ch-topics">The WindowAgg plan node appears directly above the Sort that satisfies the window's ORDER BY in every EXPLAIN output.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Sorting costs and spec sharing</span><span class="cp-ch-topics">Identical window specifications share one Sort and one WindowAgg node, so multiple functions add no extra sorting cost.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Index considerations for window ORDER BY</span><span class="cp-ch-topics">An index matching the window's PARTITION BY and ORDER BY columns lets PostgreSQL skip the sort step entirely.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Anti-patterns: filtering on window output vs source columns</span><span class="cp-ch-topics">Filtering on a window's output forces a full table scan; filtering on source columns lets the optimizer push predicates earlier.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Execution plans and the WindowAgg node</span><span class="cp-ch-topics">Read an execution plan to identify where window sorting cost is paid.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Sorting costs and spec sharing</span><span class="cp-ch-topics">Write multiple window functions that share one sort pass for free.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">Index considerations for window ORDER BY</span><span class="cp-ch-topics">Use index design to eliminate the sort step from window queries.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Anti-patterns: filtering on window output vs source columns</span><span class="cp-ch-topics">Filter on source columns instead of window output to enable early predicate pushdown.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/performance/reading-explain/">Reading EXPLAIN</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-explain-anatomy.svg" alt="EXPLAIN output anatomy">
-          <figcaption>Every window query produces a Sort node feeding a WindowAgg node — sorting cost is always paid and shows up as a high startup cost.</figcaption>
+          <figcaption>Recognize the Sort and WindowAgg nodes that every window query produces.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 06 · EXPLAIN window query</div>
@@ -332,18 +344,20 @@ select surname, laps,
       <p class="cp-part-meta">Advanced · 5 topics</p>
       <p class="cp-part-desc">When a window result must be filtered or joined, wrap it in a CTE or subquery — window functions cannot appear in WHERE or HAVING. Multi-pass patterns with chained CTEs and LATERAL are covered here.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 18 — Understanding Window Functions</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">CTEs for multi-pass computations</span><span class="cp-ch-topics">CTEs isolate each window pass into a named step, making multi-stage analytical queries readable and independently testable.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Subquery filter pattern</span><span class="cp-ch-topics">Window results cannot be filtered in the same SELECT that computes them; wrap the window in a subquery and filter outside.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">LATERAL joins with window functions</span><span class="cp-ch-topics">LATERAL lets a subquery containing a window function reference columns from the outer query row by row.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Chained window passes</span><span class="cp-ch-topics">Chained CTEs materialize each window pass so the next step can apply its own window over the previous result.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Query refactoring from correlated subqueries</span><span class="cp-ch-topics">Replacing correlated subqueries with window functions aggregates the dataset once instead of re-executing per outer row.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">CTEs for multi-pass computations</span><span class="cp-ch-topics">Break complex multi-stage queries into readable, independently testable named steps.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Subquery filter pattern</span><span class="cp-ch-topics">Filter on a window's computed result by wrapping it in an outer query.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">LATERAL joins with window functions</span><span class="cp-ch-topics">Combine a per-row subquery with a window function for row-aware lookups.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Chained window passes</span><span class="cp-ch-topics">Layer window calculations so each pass can build on the previous result.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Query refactoring from correlated subqueries</span><span class="cp-ch-topics">Replace slow correlated subqueries with a single window scan of the dataset.</span></div></div>
+        <p class="cp-yesql-refs"><i class="fa-solid fa-graduation-cap"></i> Free preview: <a href="/yesql/joins-and-relations/lateral-join-top-n/">LATERAL: Top-N Per Group</a></p>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-cte-pipeline.svg" alt="CTE pipeline">
-          <figcaption>CTEs chain window passes so each step builds on the previous result without re-scanning the table</figcaption>
+          <figcaption>See how chained named steps build analytical results without re-scanning data.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 07 · Multi-pass CTE standings</div>
@@ -387,18 +401,19 @@ select d.surname,
       <p class="cp-part-meta">Architect · 5 topics</p>
       <p class="cp-part-desc">Materialized views cache expensive window computations and support incremental refresh for rolling metrics. This module covers ELT patterns and trade-offs when moving work to columnar OLAP systems.</p>
     </div>
+    <p class="cp-book-ref"><i class="fa-solid fa-book-open"></i> Book reference: <a href="/book/contents/#part-4">Chapter 18 — Understanding Window Functions</a></p>
     <div class="cp-part-body">
       <div class="cp-chapters">
-        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Materialized views for pre-computed standings</span><span class="cp-ch-topics">Materialized views store the window computation result physically so repeated reads pay a table scan, not a re-sort.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Incremental computation</span><span class="cp-ch-topics">Incremental updates append only new rows and recompute rolling window metrics over the already-summarized data.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">ETL/ELT patterns: deduplication, surrogate keys, pre-computation</span><span class="cp-ch-topics">ELT uses ROW_NUMBER for deduplication and SUM OVER for pre-computed running totals as part of the load step.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Trade-offs with OLAP systems (Redshift, BigQuery, DuckDB)</span><span class="cp-ch-topics">At hundreds of millions of rows the sort cost in PostgreSQL becomes prohibitive and columnar engines gain a structural advantage.</span></div></div>
-        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Data architecture patterns</span><span class="cp-ch-topics">Three-layer ELT architecture separates raw staging from integrated window-function output and presentation-layer materialized views.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">01</span><div><span class="cp-ch-title">Materialized views for pre-computed standings</span><span class="cp-ch-topics">Store expensive window results physically so repeated queries pay no re-sort cost.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">02</span><div><span class="cp-ch-title">Incremental computation</span><span class="cp-ch-topics">Update rolling metrics incrementally without reprocessing the entire dataset.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">03</span><div><span class="cp-ch-title">ETL/ELT patterns: deduplication, surrogate keys, pre-computation</span><span class="cp-ch-topics">Deduplicate and pre-aggregate data as part of the data loading pipeline.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">04</span><div><span class="cp-ch-title">Trade-offs with OLAP systems (Redshift, BigQuery, DuckDB)</span><span class="cp-ch-topics">Decide when to keep analytics in PostgreSQL versus move to a columnar engine.</span></div></div>
+        <div class="cp-chapter"><span class="cp-ch-num">05</span><div><span class="cp-ch-title">Data architecture patterns</span><span class="cp-ch-topics">Design a layered data architecture that separates staging from presentation.</span></div></div>
       </div>
       <div class="cp-showcase">
         <figure class="cp-diagram">
           <img src="/img/diagrams/fig-data-access-service.svg" alt="Data architecture layers">
-          <figcaption>Three-layer ELT architecture: raw → integrated → presentation; materialized views cache expensive window computations at the integration layer.</figcaption>
+          <figcaption>See how raw, integrated, and presentation layers structure an analytical pipeline.</figcaption>
         </figure>
         <div class="cp-query-card">
           <div class="cp-query-label">Module 08 · ELT cumulative standings</div>

--- a/layouts/partials/course/course-overview.html
+++ b/layouts/partials/course/course-overview.html
@@ -2,14 +2,14 @@
   <div class="wrapper">
     <header class="co-header">
       <h2>6 Courses. 48 Modules. One System.</h2>
-      <p class="co-sub">Window functions, aggregation, schema design, advanced JOINs, query optimization, and reading query plans — each course is 8 modules across Core, Advanced, and Architect tiers.</p>
+      <p class="co-sub">Master Window Functions, Reliable Aggregation, Data Modeling for Performance, Advanced JOIN Techniques, Query Optimization Fundamentals, and Read Query Plans — each course is 8 modules across Core, Advanced, and Architect tiers.</p>
       <a href="/course/contents/" class="co-browse-link">Browse the full 48-module curriculum →</a>
     </header>
 
     <div class="co-grid">
       <a href="/course/window-functions/" class="co-card">
         <span class="co-num">01</span>
-        <h3>Window Functions</h3>
+        <h3>Master Window Functions</h3>
         <p>OVER, PARTITION BY, frame clauses, sessionization. The SQL feature most developers underuse.</p>
         <span class="co-meta">8 modules · Core → Architect</span>
       </a>
@@ -21,7 +21,7 @@
       </a>
       <a href="/course/data-modeling/" class="co-card">
         <span class="co-num">03</span>
-        <h3>Data &amp; Schema Design</h3>
+        <h3>Data Modeling for Performance</h3>
         <p>Normal forms, primary keys, index design, schema evolution, and JSONB for semi-structured data.</p>
         <span class="co-meta">8 modules · Core → Architect</span>
       </a>
@@ -33,13 +33,13 @@
       </a>
       <a href="/course/query-optimization/" class="co-card">
         <span class="co-num">05</span>
-        <h3>Query Optimization</h3>
+        <h3>Query Optimization Fundamentals</h3>
         <p>How PostgreSQL executes queries, bottleneck detection, query rewriting, and indexing strategy.</p>
         <span class="co-meta">8 modules · Core → Architect</span>
       </a>
       <a href="/course/read-query-plans/" class="co-card">
         <span class="co-num">06</span>
-        <h3>Reading Query Plans</h3>
+        <h3>Read Query Plans</h3>
         <p>EXPLAIN anatomy, plan node types, row estimate mismatches, and a complete diagnostic workflow.</p>
         <span class="co-meta">8 modules · Core → Architect</span>
       </a>

--- a/layouts/partials/course/faq.html
+++ b/layouts/partials/course/faq.html
@@ -49,7 +49,7 @@
       <li>
         <div class="faq_item">
           <h6>What does the 48-module curriculum cover?</h6>
-          <p>Six courses — Window Functions, Reliable Aggregation, Data Modeling for Performance, Advanced JOIN Techniques, Query Optimization, and Reading Query Plans — each with 8 modules across Core, Advanced, and Architect tiers. <a href="/course/contents/">Browse the full 48-module curriculum →</a></p>
+          <p>Six courses — Master Window Functions, Reliable Aggregation, Data Modeling for Performance, Advanced JOIN Techniques, Query Optimization Fundamentals, and Read Query Plans — each with 8 modules across Core, Advanced, and Architect tiers. <a href="/course/contents/">Browse the full 48-module curriculum →</a></p>
         </div>
       </li>
     </ul>

--- a/layouts/partials/course/hero.html
+++ b/layouts/partials/course/hero.html
@@ -1,28 +1,34 @@
-<style>
-.course_hero .hero_cta .button.button_transparent,
-.course_hero .hero_cta .button.button_transparent:visited {
-  border-color: rgba(255,255,255,0.4);
-  color: rgba(255,255,255,0.85);
-}
-.course_hero .hero_cta .button.button_transparent:hover {
-  background: rgba(255,255,255,0.1);
-  border-color: rgba(255,255,255,0.7);
-  color: #fff;
-}
-</style>
-<div id="course" class="course_hero">
-  <div class="wrapper">
-    <h1>The Course That Picks Up Where the Book Leaves Off</h1>
-    
-    <p class="hero_subtitle">
-      Built from years of teaching PostgreSQL to working developers.
-      Six courses, three tiers — from solid SQL foundations to
-      production-grade data system design.
-    </p>
-    
-    <div class="hero_cta">
-      <a href="https://sales.theartofpostgresql.com/the-art-of-postgresql-courses/" class="button button_purple button_large">Join the Course</a>
-      <a href="#curriculum" class="button button_transparent button_large">See What's Included</a>
+<div id="course" class="welcome_slider">
+  <div style="position: relative; min-height: 100vh; overflow: hidden;">
+    <img src="/images/demo/slide.jpg" alt=""
+         style="position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; object-position: center; z-index: 0;">
+    <i class="fa-solid fa-graduation-cap"
+       style="position: absolute; right: -60px; top: 50%; transform: translateY(-50%);
+              font-size: 520px; opacity: 0.08; color: #fff; line-height: 1;
+              pointer-events: none; z-index: 1;"></i>
+    <div style="position: relative; z-index: 2; min-height: 100vh; max-width: 700px; margin: 0 auto;
+                display: flex; flex-flow: column nowrap; justify-content: center; align-items: center;
+                text-align: center; padding: 0 24px;">
+      <i class="fa-solid fa-graduation-cap"
+         style="font-size: 3.5rem; color: rgba(255,255,255,0.55); margin-bottom: 28px;"></i>
+      <h1 style="color: #fff; font-size: 3rem; font-weight: 700; margin: 0 0 20px 0; line-height: 1.1;
+                 font-family: Lato, sans-serif; letter-spacing: -0.01em;">
+        The Course That Picks Up Where the Book Leaves Off
+      </h1>
+      <p style="color: rgba(255,255,255,0.65); font-size: 1.1rem; line-height: 1.65;
+                max-width: 500px; margin: 0 0 44px 0; font-family: Lato, sans-serif; font-weight: 300;">
+        Built from years of teaching PostgreSQL to working developers.
+        Six courses, three tiers — from solid SQL foundations to
+        production-grade data system design.
+      </p>
+      <div style="display: flex; gap: 20px; flex-wrap: wrap; justify-content: center;">
+        <a href="https://sales.theartofpostgresql.com/the-art-of-postgresql-courses/"
+           class="button button_large">Join the Course</a>
+        <a href="#curriculum" class="button button_large"
+           style="background: transparent; border-color: rgba(255,255,255,0.45); color: rgba(255,255,255,0.85);"
+           onmouseover="this.style.background='rgba(255,255,255,0.1)';this.style.borderColor='rgba(255,255,255,0.7)';this.style.color='#fff'"
+           onmouseout="this.style.background='transparent';this.style.borderColor='rgba(255,255,255,0.45)';this.style.color='rgba(255,255,255,0.85)'">See What's Included</a>
+      </div>
     </div>
   </div>
 </div>

--- a/layouts/partials/course/toc-styles.html
+++ b/layouts/partials/course/toc-styles.html
@@ -123,4 +123,23 @@
   .cp-diagram { margin:0; max-width:100%; min-width:0; }
   .cp-diagram img { width:100%; max-width:100%; height:auto; display:block; border-radius:4px; }
   .cp-diagram figcaption { font:300 0.76rem/1.4 'Lato',sans-serif; color:#9e8fb0; text-align:center; margin-top:6px; }
+
+  /* ── Cross-references ── */
+  .cp-book-ref, .cp-yesql-refs {
+    font: 400 0.82rem/1.4 'Lato', sans-serif;
+    color: #6b6274;
+    margin: 12px 0;
+  }
+  .cp-book-ref { margin-bottom: 0; }
+  .cp-book-ref i, .cp-yesql-refs i { color: #60b2d3; margin-right: 6px; }
+  .cp-book-ref a, .cp-yesql-refs a {
+    color: #60b2d3;
+    text-decoration: none;
+    border-bottom: 1px dashed rgba(96,178,211,0.4);
+  }
+  .cp-book-ref a:hover, .cp-yesql-refs a:hover {
+    color: #372649;
+    border-bottom-color: #372649;
+  }
+  .cp-yesql-refs { padding: 10px 12px; background: rgba(96,178,211,0.05); border-radius: 4px; border: 1px solid rgba(96,178,211,0.18); margin-top: 16px; }
 </style>

--- a/layouts/section/course.html
+++ b/layouts/section/course.html
@@ -1,6 +1,5 @@
 {{ partial "course/head.html" . }}
 {{ partial "header.html" . }}
-{{ partial "course/caroussel.html" . }}
 {{ partial "course/hero.html" . }}
 {{ partial "course/early-access.html" . }}
 {{ partial "book/social-proof.html" . }}


### PR DESCRIPTION
## What's in this PR

### Fix 1 — Canonical course names
Align course names across `course-overview.html`, `faq.html`, and all 6 per-course pages to the authoritative README titles:
- Master Window Functions
- Reliable Aggregation
- Data Modeling for Performance
- Advanced JOIN Techniques
- Query Optimization Fundamentals
- Read Query Plans

### Fix 2 — Learner-outcome topic descriptions
Rewrite all `cp-ch-topics` spans on 6 course pages from technique labels to first-person learner-outcome sentences. Also rewrite `figcaption` elements inside `.cp-diagram` figures.

### Fix 3 — Cross-links per module
Add `cp-book-ref` (book chapter anchor link) and `cp-yesql-refs` (free preview lesson links) to every module on all 6 course pages. Add supporting CSS to `toc-styles.html`.

### Fix 4 — Remove competing H1
Remove the `caroussel.html` partial from the course section layout. It rendered a full-screen "PostgreSQL Courses" H1 that competed with and weakened the main hero headline.

### Hero redesign
Replace the flat dark-purple `course_hero` with a full-viewport `welcome_slider` hero matching the workshop and lab pages: `slide.jpg` as an absolute-cover background image, `fa-graduation-cap` icon in the foreground and ghosted large on the right edge, centred flex column, transparent sticky nav.
