### PR TITLE
lab: replace left-border card style with full-border + hover lift

### DIFF
--- a/themes/taop/static/css/style.css
+++ b/themes/taop/static/css/style.css
@@ -3434,19 +3434,24 @@ body.course .welcome_slider ul li {
 }
 .lab_usecases .usecase_list li {
   background: #fff;
-  padding: 20px 25px;
+  padding: 24px 26px;
   border-radius: 8px;
-  border-left: 4px solid #372649;
+  border: 1px solid #ddd6ea;
+  transition: box-shadow 0.18s, transform 0.18s;
+}
+.lab_usecases .usecase_list li:hover {
+  box-shadow: 0 4px 20px rgba(55,38,73,0.12);
+  transform: translateY(-2px);
 }
 .lab_usecases .usecase_list h6 {
   color: #372649;
-  font: 700 16px 'Lato';
-  padding: 0 0 8px 0;
+  font: 700 1rem/1.2 'Lato', sans-serif;
+  margin: 0 0 8px;
+  padding: 0;
 }
 .lab_usecases .usecase_list p {
   color: #67527a;
-  font-size: 14px;
-  line-height: 1.5;
+  font: 300 0.88rem/1.55 'Lato', sans-serif;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
The "What You Can Practice" usecase cards had `border-left: 4px solid #372649` — an accent stripe that doesn't match any other card on the site.

Replaced with the standard card language used by the course overview and tier cards:
- `border: 1px solid #ddd6ea` (full perimeter border)
- Hover: `box-shadow 0 4px 20px rgba(55,38,73,0.12)` + `translateY(-2px)` lift
- `transition: box-shadow 0.18s, transform 0.18s`

Also tightened `h6` and `p` typography to Lato conventions (`font:` shorthand with weight, size, line-height).