### PR TITLE
seo: add canonical tags sitewide + alias for /explain-plan-visualizer/

### DIFF
--- a/content/page/explain-plan-visualizer.md
+++ b/content/page/explain-plan-visualizer.md
@@ -1,4 +1,5 @@
 +++
+aliases = ["/explain-plan-visualizer/"]
 date = "2019-11-06T21:45:00+02:00"
 title = "PostgreSQL Query Plan Visualizer"
 tags = ["PostgreSQL", "Query Plan", "Visualizer", "PEV"]

--- a/layouts/book/book-updates.html
+++ b/layouts/book/book-updates.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Second Edition, Updated (2026) | The Art of PostgreSQL</title>
+  <link rel="canonical" href="{{ .Permalink }}">
   <meta name="description" content="The 2026 update adds a pgvector chapter, 56 new figures, full PostgreSQL 12–18 coverage, and an integrated companion lab. Free for all existing purchasers.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <meta name="twitter:card" content="summary" />

--- a/layouts/launch.html
+++ b/layouts/launch.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>The Art of PostgreSQL — Second Edition, Updated (2026)</title>
+    <link rel="canonical" href="{{ .Permalink }}">
     <meta name="description" content="The 2026 edition is here. Now covering PostgreSQL 10–18, with a new chapter on pgvector, 56 new figures, and an integrated companion lab. Free update for existing purchasers.">
     <meta name="robots" content="noindex, nofollow">
 

--- a/layouts/newsletter.html
+++ b/layouts/newsletter.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>The Art of PostgreSQL — Master Window Functions Workshop</title>
+    <link rel="canonical" href="{{ .Permalink }}">
     <meta name="description" content="A 3-hour live deep dive into PostgreSQL window functions with the author of The Art of PostgreSQL. Real queries. Real data. Real-time Q&A.">
     <meta name="robots" content="noindex">
 

--- a/layouts/page/contents.html
+++ b/layouts/page/contents.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Table of Contents | The Art of PostgreSQL</title>
+   <link rel="canonical" href="{{ .Permalink }}">
   <meta name="description" content="Full table of contents for The Art of PostgreSQL: 8 parts, 53 chapters, 437 SQL queries across 15 real-world datasets. A spiral learning path from SQL fundamentals to PostgreSQL extensions.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <meta name="twitter:card" content="summary" />

--- a/layouts/page/course-advanced-joins.html
+++ b/layouts/page/course-advanced-joins.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Course 4 — Advanced JOIN Techniques | The Art of PostgreSQL</title>
+   <link rel="canonical" href="{{ .Permalink }}">
   <meta name="description" content="8-module curriculum: join fundamentals through architecture-level schema design. f1db, chinook, tweet, and geoname datasets.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <meta property="og:url" content="https://theartofpostgresql.com/course/advanced-joins/" />

--- a/layouts/page/course-aggregation.html
+++ b/layouts/page/course-aggregation.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Course 2 — Reliable Aggregation | The Art of PostgreSQL</title>
+   <link rel="canonical" href="{{ .Permalink }}">
   <meta name="description" content="8-module curriculum: GROUP BY semantics through incremental ELT patterns. f1db Formula One dataset throughout.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <meta property="og:url" content="https://theartofpostgresql.com/course/aggregation/" />

--- a/layouts/page/course-contents.html
+++ b/layouts/page/course-contents.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Course Contents — 6 PostgreSQL Courses | The Art of PostgreSQL</title>
+   <link rel="canonical" href="{{ .Permalink }}">
   <meta name="description" content="6 courses, 48 modules, 3 tiers. A complete practical PostgreSQL curriculum: window functions, aggregation, data modeling, JOINs, query optimization, and reading query plans.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <meta name="twitter:card" content="summary" />

--- a/layouts/page/course-data-modeling.html
+++ b/layouts/page/course-data-modeling.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Course 3 — Data Modeling for Performance | The Art of PostgreSQL</title>
+   <link rel="canonical" href="{{ .Permalink }}">
   <meta name="description" content="8-module curriculum: relational model foundations through JSONB document patterns. chinook and f1db datasets.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <meta property="og:url" content="https://theartofpostgresql.com/course/data-modeling/" />

--- a/layouts/page/course-query-optimization.html
+++ b/layouts/page/course-query-optimization.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Course 5 — Query Optimization Fundamentals | The Art of PostgreSQL</title>
+   <link rel="canonical" href="{{ .Permalink }}">
   <meta name="description" content="8-module curriculum: cost model and EXPLAIN basics through systematic optimization workflow. f1db, chinook, and geoname datasets.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <meta property="og:url" content="https://theartofpostgresql.com/course/query-optimization/" />

--- a/layouts/page/course-read-query-plans.html
+++ b/layouts/page/course-read-query-plans.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Course 6 — Read Query Plans | The Art of PostgreSQL</title>
+   <link rel="canonical" href="{{ .Permalink }}">
   <meta name="description" content="8-module curriculum: EXPLAIN anatomy through full observability workflow. f1db and chinook datasets.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <meta property="og:url" content="https://theartofpostgresql.com/course/read-query-plans/" />

--- a/layouts/page/course-toc.html
+++ b/layouts/page/course-toc.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>{{ .Title }} | The Art of PostgreSQL</title>
+   <link rel="canonical" href="{{ .Permalink }}">
   <meta name="description" content="Full curriculum for {{ .Params.course_title }}: 8 modules, 3 tiers. {{ .Params.course_tagline }}">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <meta name="twitter:card" content="summary" />

--- a/layouts/page/course-window-functions.html
+++ b/layouts/page/course-window-functions.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Course 1 — Master Window Functions | The Art of PostgreSQL</title>
+   <link rel="canonical" href="{{ .Permalink }}">
   <meta name="description" content="8-module curriculum: OVER-clause foundations through materialized-view ELT patterns. f1db Formula One dataset throughout.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <meta property="og:url" content="https://theartofpostgresql.com/course/window-functions/" />

--- a/layouts/page/sql-and-ai.html
+++ b/layouts/page/sql-and-ai.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>SQL and AI: Why You Still Need to Understand SQL | The Art of PostgreSQL</title>
+   <link rel="canonical" href="{{ .Permalink }}">
   <meta name="description" content="AI tools can generate queries. They cannot understand your database, architect your schema, or catch what goes silently wrong. That is still a human job.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <meta name="twitter:card" content="summary" />

--- a/layouts/page/updates.html
+++ b/layouts/page/updates.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>What's New | The Art of PostgreSQL</title>
+   <link rel="canonical" href="{{ .Permalink }}">
   <meta name="description" content="A record of the project — book editions, lessons, lab, and open-source tools from 2011 to today.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <meta name="twitter:card" content="summary" />

--- a/layouts/partials/book/head-fair-pricing.html
+++ b/layouts/partials/book/head-fair-pricing.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>The Art of PostgreSQL — Fair Pricing for the Book</title>
+	<link rel="canonical" href="{{ .Permalink }}">
 	<meta name="description" content="The PostgreSQL book for developers that teaches you how to turn thousands of lines of code into simple queries.">
 
         <!-- twitter card integration -->

--- a/layouts/partials/book/head.html
+++ b/layouts/partials/book/head.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>The Art of PostgreSQL — Practical PostgreSQL for Developers</title>
+	<link rel="canonical" href="{{ .Permalink }}">
 	<meta name="description" content="The PostgreSQL book for developers that teaches you how to turn thousands of lines of code into simple queries.">
 
         <!-- twitter card integration -->

--- a/layouts/partials/course/head.html
+++ b/layouts/partials/course/head.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>The Art of PostgreSQL — Master PostgreSQL with a Practical System</title>
+	<link rel="canonical" href="{{ .Permalink }}">
 	<meta name="description" content="Learn SQL, performance, and data modeling with real-world techniques — not theory. Master PostgreSQL with a complete, practical system.">
 
 	<meta name="twitter:card" content="summary" />

--- a/layouts/partials/index/head.html
+++ b/layouts/partials/index/head.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>The Art of PostgreSQL: a PostgreSQL book for developers in 2026</title>
+	<link rel="canonical" href="{{ .Permalink }}">
 	<meta name="description" content="Learn SQL, performance, and data modeling with real-world techniques — not theory. Master PostgreSQL with a complete, practical system.">
 
 	<meta name="twitter:card" content="summary" />

--- a/layouts/partials/lab/head.html
+++ b/layouts/partials/lab/head.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>The Art of PostgreSQL — Practice PostgreSQL on Real Data</title>
+	<link rel="canonical" href="{{ .Permalink }}">
 	<meta name="description" content="A free, interactive lab to practice PostgreSQL SQL, performance, and data modeling on real-world datasets.">
 
 	<meta name="twitter:card" content="summary" />

--- a/layouts/partials/workshop/head.html
+++ b/layouts/partials/workshop/head.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>The Art of PostgreSQL — Advanced PostgreSQL Workshops (3h)</title>
+	<link rel="canonical" href="{{ .Permalink }}">
 	<meta name="description" content="Advanced PostgreSQL Workshops — Master SQL, Performance, and Query Optimization with the Author of The Art of PostgreSQL">
 
         <!-- twitter card integration -->

--- a/layouts/partials/yesql/head.html
+++ b/layouts/partials/yesql/head.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>{{ with .Title }}{{ . }} · {{ end }}The Art of PostgreSQL</title>
+	<link rel="canonical" href="{{ .Permalink }}">
 	<meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Params.summary }}{{ . }}{{ else }}Practical PostgreSQL for developers, one concept at a time.{{ end }}{{ end }}">
 
 	<meta name="twitter:card" content="summary" />

--- a/themes/taop/layouts/partials/head.html
+++ b/themes/taop/layouts/partials/head.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>The Art of PostgreSQL: a PostgreSQL book for developers in 2026</title>
+	<link rel="canonical" href="{{ .Permalink }}">
 	<meta name="description" content="The PostgreSQL book for developers that teaches you how to turn thousands of lines of code into simple queries.">
 
         <!-- twitter card integration -->

--- a/themes/taop/layouts/partials/post/head.html
+++ b/themes/taop/layouts/partials/post/head.html
@@ -4,6 +4,7 @@
     {{ hugo.Generator }}
     <meta charset="utf-8" />
     <title>The Art of PostgreSQL - {{ .Title }}</title>
+    <link rel="canonical" href="{{ .Permalink }}">
     <meta name="description" content="{{ .Summary }}" />
 
     <!-- twitter card integration -->


### PR DESCRIPTION
## What

Adds `<link rel="canonical" href="{{ .Permalink }}">` to every page on the site, and adds a redirect alias for the moved explain-plan-visualizer page.

## Why

Google Search Console reported two actionable issues:

**Duplicate without user-selected canonical (6 pages)** — the site had no canonical tags anywhere. Google was crawling homepage variants with query strings (`?utm_source=…`, `?ref=…`, `?affiliate=…`) and new YeSQL lesson pages and couldn't determine which URL was authoritative. This is the root cause.

**Not found (404)** for `/explain-plan-visualizer/` — the page was moved to `/page/explain-plan-visualizer/` at some point with no redirect. Adding `aliases` restores the old URL via Hugo's redirect mechanism.

## Changes

- `<link rel="canonical">` added to **9 head partials**:
  - `themes/taop/layouts/partials/head.html` (base)
  - `themes/taop/layouts/partials/post/head.html` (blog/tag pages)
  - `layouts/partials/index/head.html`
  - `layouts/partials/book/head.html`
  - `layouts/partials/book/head-fair-pricing.html`
  - `layouts/partials/course/head.html`
  - `layouts/partials/lab/head.html`
  - `layouts/partials/workshop/head.html`
  - `layouts/partials/yesql/head.html`
- `<link rel="canonical">` added to **11 standalone page layouts** (course pages, sql-and-ai, updates, book-updates, newsletter, launch, contents)
- `aliases = ["/explain-plan-visualizer/"]` added to `content/page/explain-plan-visualizer.md`

## Expected GSC outcome (2–4 weeks)

- "Duplicate without user-selected canonical" drops from 6 to 0
- Most "Crawled – currently not indexed" query-param variants clear
- `/explain-plan-visualizer/` 404 resolves once Google recrawls
