### PR TITLE
Fix login page: submit never actually sent a magic link

### DIFF
--- a/layouts/page/welcome.html
+++ b/layouts/page/welcome.html
@@ -123,7 +123,7 @@
 <div class="welcome-hero">
   <i class="fa-solid fa-envelope-open-text welcome-icon"></i>
   <h1>Check your inbox</h1>
-  <p class="welcome-lede">Your purchase is confirmed. We've sent a sign-in link to the email address you used at checkout — click it to access the book, courses, and all downloads (PDF, ePub, slides, SQL files).</p>
+  <p class="welcome-lede">We've sent a sign-in link to the email address you just entered — click it to access the book, courses, and all downloads (PDF, ePub, slides, SQL files).</p>
 </div>
 
 <div class="welcome-page-body">

--- a/layouts/section/login.html
+++ b/layouts/section/login.html
@@ -222,21 +222,20 @@
 (function() {
   document.body.classList.add('login-page');
 
-  var form = document.querySelector('.login-form-wrap form');
-  var btn  = form.querySelector('button[type="submit"]');
-
-  form.addEventListener('submit', function(e) {
-    e.preventDefault();
-    btn.disabled = true;
-    btn.textContent = 'Sending…';
-
-    var params = new URLSearchParams(new FormData(form));
-    var url = form.action + '?' + params.toString();
-
-    fetch(url, { mode: 'no-cors' })
-      .then(function()  { window.location.href = '/welcome/'; })
-      .catch(function() { window.location.href = '/welcome/'; });
-  });
+  // Deliberately a plain, unintercepted form GET to .../login?email=... —
+  // that's cmd/admin's real, dynamically-rendered login page (see
+  // app.taop.xyz/internal/handlers/auth.go's Login handler), which
+  // pre-fills the email from the query param and embeds a fresh CSRF
+  // token + hidden "next" field in its own <form method="post"
+  // action=".../auth/magic-link">. A static Hugo page built at deploy
+  // time can never embed that per-request token itself, so the previous
+  // version of this script tried to fetch(..., {mode:"no-cors"}) the
+  // wrong endpoint (GET /login, which only ever *renders* the page, never
+  // sends anything) directly, then redirected to a fake "Check your
+  // inbox" screen regardless of what actually happened — no magic link
+  // was ever sent. One extra click on the real page (which already has a
+  // prominent "Send my sign-in link" button of its own) is the actual
+  // fix, not a fetch dance this page structurally can't complete.
 
   var $header = $('.header');
   var threshold = window.innerHeight * 0.8;


### PR DESCRIPTION
Reported directly: `/login/`'s "Send my sign-in link" button always showed the "Check your inbox" success screen, but no email ever arrived — nothing wrong with Scaleway TEM, the request never got that far.

## Root cause — three stacked bugs in the page's own JS
- Fetched `GET /login` (`cmd/admin`'s page-*render* route — shows the login form, does nothing with the email) instead of `POST /auth/magic-link` (the actual send action).
- Even hitting the right URL, it built a GET query string; the real endpoint requires a POST with a form-encoded body.
- `POST /auth/magic-link` requires a `csrf_token` cookie + matching form field (double-submit pattern), generated fresh per request by the server — something a static Hugo page built at deploy time can **structurally never embed on its own**.

On top of that, `fetch(url, {mode: 'no-cors'})` makes the response unreadable, and both `.then()`/`.catch()` redirected to the same fake success page regardless of outcome — the UI couldn't have surfaced a failure even if the URL/method/CSRF issues were fixed.

## Fix
Delete the broken submit interception entirely. The form's own `method=get action=.../login` was already correct — a plain, native browser navigation there lands on `cmd/admin`'s real, dynamically-rendered login page, which already pre-fills the email from the query param and embeds a fresh, valid CSRF token in its own working `POST /auth/magic-link` form. One extra click on that page (which has its own prominent "Send my sign-in link" button) instead of a client-side fetch dance this page could never structurally complete.

## Verification
End-to-end against the local `app.taop.xyz` dev stack (matching this repo's own `hugo.IsServer` dev-mode form action):
- `GET .../login?email=...` correctly pre-fills the email and embeds a real CSRF token.
- POSTing that token to `/auth/magic-link` returns the same success page, and mailbot's logs confirm a **real** magic-link email was generated and sent — not just a fake success screen.
- `hugo --minify` build clean, confirmed the built output has no `no-cors`/`fetch` left and the form markup is unchanged.