### PR TITLE
New /teams/ enterprise page, sitewide linking, and app/index page polish

### DIFF
--- a/content/page/teams.md
+++ b/content/page/teams.md
@@ -1,0 +1,6 @@
++++
+title = "The Art of PostgreSQL for Teams"
+slug = "teams"
+description = "License the Architect course for your team — 5 seats included, add more anytime, optionally add the Masterclass Curriculum. One dashboard to manage your whole team, no passwords."
+layout = "teams"
++++

--- a/content/page/teams.md
+++ b/content/page/teams.md
@@ -1,6 +1,6 @@
 +++
 title = "The Art of PostgreSQL for Teams"
 slug = "teams"
-description = "License the Architect course for your team — 5 seats included, add more anytime, optionally add the Masterclass Curriculum. One dashboard to manage your whole team, no passwords."
+description = "The Architect course for your whole team, under one purchase — buy exactly as many seats as your team needs, optionally add the Masterclass Curriculum. One dashboard, no passwords."
 layout = "teams"
 +++

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -12,6 +12,7 @@
 {{ partial "index/workshops.html" . }}
 {{ partial "index/lab.html" . }}
 {{ partial "index/final-cta.html" . }}
+{{ partial "index/teams.html" . }}
 {{ partial "index/system.html" . }}
 {{- /* partial "index/ecosystem.html" . */ -}}
 {{ partial "subscribe.html" . }}

--- a/layouts/page/app.html
+++ b/layouts/page/app.html
@@ -138,13 +138,20 @@
   }
 
   /* ── Feature tiles ──────────────────────────────────────── */
+  .app-features-section {
+    max-width: 820px;
+    margin: 0 auto;
+    padding: 72px 20px 0;
+    text-align: center;
+  }
   .app-features {
     max-width: 1060px;
     margin: 0 auto;
-    padding: 72px 20px 64px;
+    padding: 0 20px 64px;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: 24px;
+    text-align: left;
   }
   .feat-card {
     background: #fff;
@@ -370,7 +377,12 @@
 </div>
 
 <!-- Features -->
-<div class="app-features">
+<section class="app-features-section">
+  <div class="section-eyebrow"><i class="fa-solid fa-star"></i> Everything in one place</div>
+  <h2 class="section-title">One App for the Book, the Courses, and Live SQL</h2>
+  <p class="section-sub">Read, practice, and track your progress without juggling separate tools, accounts, or installs.</p>
+
+  <div class="app-features">
   <div class="feat-card">
     <div class="feat-icon"><i class="fa-solid fa-book-open-reader"></i></div>
     <h3>Book reader, online — and offline</h3>
@@ -401,7 +413,35 @@
     <h3>The book is yours forever</h3>
     <p>Buy once, keep it forever. Edition updates — like the 2026 Second Edition — are free for all previous purchasers. Courses are a yearly subscription, with new content added regularly.</p>
   </div>
-</div>
+  </div>
+</section>
+
+<!-- Dashboard: exercises, quizzes, leaderboard -->
+<section class="dashboard-section">
+  <div class="dashboard-inner">
+    <div class="section-eyebrow"><i class="fa-solid fa-chart-line"></i> Track your progress</div>
+    <h2 class="section-title">Your dashboard: chapters, exercises, and quizzes</h2>
+    <p class="section-sub">Every chapter and module comes with hands-on exercises and short quizzes to check what actually stuck — not just a progress bar. Your dashboard tracks what you've read, what you've solved, and what's left.</p>
+
+    <div class="dash-features">
+      <div class="dash-feature">
+        <i class="fa-solid fa-flask"></i>
+        <h4>Hands-on exercises</h4>
+        <p>Real SQL problems tied to the chapter or module you just read — run your own query against the same live database and compare it to the reference solution.</p>
+      </div>
+      <div class="dash-feature">
+        <i class="fa-solid fa-list-check"></i>
+        <h4>Short quizzes</h4>
+        <p>A handful of questions per chapter or module to check what stuck — not graded homework, just a quick gut check.</p>
+      </div>
+      <div class="dash-feature">
+        <i class="fa-solid fa-trophy"></i>
+        <h4>Leaderboard (optional)</h4>
+        <p>Points from exercises and quizzes, if you want to track them — opt-in, visible only if you choose to show it.</p>
+      </div>
+    </div>
+  </div>
+</section>
 
 <!-- Live database section -->
 <section class="live-db-section">
@@ -543,33 +583,6 @@
         </tr>
       </tbody>
     </table>
-  </div>
-</section>
-
-<!-- Dashboard: exercises, quizzes, leaderboard -->
-<section class="dashboard-section">
-  <div class="dashboard-inner">
-    <div class="section-eyebrow"><i class="fa-solid fa-chart-line"></i> Track your progress</div>
-    <h2 class="section-title">Your dashboard: chapters, exercises, and quizzes</h2>
-    <p class="section-sub">Every chapter and module comes with hands-on exercises and short quizzes to check what actually stuck — not just a progress bar. Your dashboard tracks what you've read, what you've solved, and what's left.</p>
-
-    <div class="dash-features">
-      <div class="dash-feature">
-        <i class="fa-solid fa-flask"></i>
-        <h4>Hands-on exercises</h4>
-        <p>Real SQL problems tied to the chapter or module you just read — run your own query against the same live database and compare it to the reference solution.</p>
-      </div>
-      <div class="dash-feature">
-        <i class="fa-solid fa-list-check"></i>
-        <h4>Short quizzes</h4>
-        <p>A handful of questions per chapter or module to check what stuck — not graded homework, just a quick gut check.</p>
-      </div>
-      <div class="dash-feature">
-        <i class="fa-solid fa-trophy"></i>
-        <h4>Leaderboard (optional)</h4>
-        <p>Points from exercises and quizzes, if you want to track them — opt-in, visible only if you choose to show it.</p>
-      </div>
-    </div>
   </div>
 </section>
 

--- a/layouts/page/app.html
+++ b/layouts/page/app.html
@@ -182,7 +182,7 @@
 
   /* ── Live database section ──────────────────────────────── */
   .live-db-section {
-    background: #fff;
+    background: #f8f7f9;
     padding: 72px 20px;
     border-top: 1px solid #ede8f5;
     border-bottom: 1px solid #ede8f5;
@@ -191,7 +191,7 @@
 
   /* ── Docker lab section ──────────────────────────────────── */
   .docker-section {
-    background: #f8f7f9;
+    background: #fff;
     padding: 72px 20px;
     border-bottom: 1px solid #ede8f5;
   }
@@ -205,7 +205,7 @@
   .docker-cols .docker-text { flex: 1; }
   .docker-cols .docker-aside {
     flex: 0 0 260px;
-    background: #fff;
+    background: #f8f7f9;
     border: 1px solid #e4dced;
     border-radius: 8px;
     padding: 20px 22px;
@@ -231,7 +231,7 @@
 
   /* ── Comparison table ───────────────────────────────────── */
   .compare-section {
-    background: #fff;
+    background: #f8f7f9;
     padding: 72px 20px;
   }
   .compare-inner { max-width: 960px; margin: 0 auto; }
@@ -325,7 +325,7 @@
 
   /* ── Team dashboard ──────────────────────────────────────── */
   .team-app-section {
-    background: #f8f7f9;
+    background: #fff;
     padding: 72px 20px;
     border-bottom: 1px solid #ede8f5;
   }
@@ -342,7 +342,7 @@
     align-items: center;
     gap: 8px;
     padding: 18px 12px;
-    background: #fff;
+    background: #f8f7f9;
     border: 1px solid #ede8f5;
     border-radius: 8px;
   }
@@ -441,6 +441,26 @@
         <p>Points from exercises and quizzes, if you want to track them — opt-in, visible only if you choose to show it.</p>
       </div>
     </div>
+  </div>
+</section>
+
+<!-- Team dashboard -->
+<section class="team-app-section">
+  <div class="team-app-inner">
+    <div class="section-eyebrow"><i class="fa-solid fa-users"></i> Managing a team?</div>
+    <h2 class="section-title">An Enterprise dashboard, layered on top</h2>
+    <p class="section-sub">Buying for your team adds an Enterprise dashboard to the same app — on top of your own student dashboard, not a separate tool.</p>
+
+    <div class="team-app-list">
+      <div class="team-app-item"><i class="fa-solid fa-sitemap"></i><span>Create &amp; manage teams</span></div>
+      <div class="team-app-item"><i class="fa-solid fa-file-csv"></i><span>Add members via form or CSV</span></div>
+      <div class="team-app-item"><i class="fa-solid fa-user-check"></i><span>Assign &amp; reassign seats</span></div>
+      <div class="team-app-item"><i class="fa-solid fa-envelope-open-text"></i><span>Magic-link invites</span></div>
+      <div class="team-app-item"><i class="fa-solid fa-chart-line"></i><span>Per-member progress</span></div>
+      <div class="team-app-item"><i class="fa-solid fa-trophy"></i><span>Team leaderboard</span></div>
+    </div>
+
+    <a href="/teams/" class="button button_purple button_large">See Team Pricing</a>
   </div>
 </section>
 
@@ -586,26 +606,6 @@
       </tbody>
     </table>
   </div>
-  </div>
-</section>
-
-<!-- Team dashboard -->
-<section class="team-app-section">
-  <div class="team-app-inner">
-    <div class="section-eyebrow"><i class="fa-solid fa-users"></i> Managing a team?</div>
-    <h2 class="section-title">An Enterprise dashboard, layered on top</h2>
-    <p class="section-sub">Buying for your team adds an Enterprise dashboard to the same app — on top of your own student dashboard, not a separate tool.</p>
-
-    <div class="team-app-list">
-      <div class="team-app-item"><i class="fa-solid fa-sitemap"></i><span>Create &amp; manage teams</span></div>
-      <div class="team-app-item"><i class="fa-solid fa-file-csv"></i><span>Add members via form or CSV</span></div>
-      <div class="team-app-item"><i class="fa-solid fa-user-check"></i><span>Assign &amp; reassign seats</span></div>
-      <div class="team-app-item"><i class="fa-solid fa-envelope-open-text"></i><span>Magic-link invites</span></div>
-      <div class="team-app-item"><i class="fa-solid fa-chart-line"></i><span>Per-member progress</span></div>
-      <div class="team-app-item"><i class="fa-solid fa-trophy"></i><span>Team leaderboard</span></div>
-    </div>
-
-    <a href="/teams/" class="button button_purple button_large">See Team Pricing</a>
   </div>
 </section>
 

--- a/layouts/page/app.html
+++ b/layouts/page/app.html
@@ -188,6 +188,61 @@
     border-bottom: 1px solid #ede8f5;
   }
   .live-db-inner { max-width: 820px; margin: 0 auto; }
+  .live-db-cta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-top: 32px;
+    padding: 24px;
+    background: #fff;
+    border: 1px solid #ede8f5;
+    border-radius: 8px;
+  }
+  .live-db-cta p {
+    margin: 0;
+    font: 700 .95rem/1.4 'Lato', sans-serif;
+    color: #372649;
+    flex: 1 1 220px;
+  }
+  .live-db-cta form {
+    display: flex;
+    gap: 10px;
+    flex: 1 1 320px;
+  }
+  .live-db-cta input[type="email"] {
+    flex: 1;
+    min-width: 0;
+    height: 46px;
+    padding: 0 14px;
+    font-size: .95rem;
+    color: #372649;
+    background: #f8f7f9;
+    border: 1px solid #ede8f5;
+    border-radius: 6px;
+    outline: none;
+  }
+  .live-db-cta input[type="email"]:focus { box-shadow: 0 0 0 3px rgba(96,178,211,.35); }
+  .live-db-cta input[type="email"]::placeholder { color: #896da1; }
+  .live-db-cta button {
+    flex: 0 0 auto;
+    height: 46px;
+    padding: 0 20px;
+    background: #372649;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    font: 700 .82rem/1 'Lato', sans-serif;
+    letter-spacing: .03em;
+    cursor: pointer;
+    transition: background .15s;
+    white-space: nowrap;
+  }
+  .live-db-cta button:hover { background: #60b2d3; }
+  @media (max-width: 560px) {
+    .live-db-cta form { flex-direction: column; }
+    .live-db-cta button { width: 100%; }
+  }
 
   /* ── Docker lab section ──────────────────────────────────── */
   .docker-section {
@@ -330,6 +385,7 @@
     border-bottom: 1px solid #ede8f5;
   }
   .team-app-inner { max-width: 780px; margin: 0 auto; }
+  .team-app-cta { text-align: center; }
   .team-app-list {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -460,7 +516,9 @@
       <div class="team-app-item"><i class="fa-solid fa-trophy"></i><span>Team leaderboard</span></div>
     </div>
 
-    <a href="/teams/" class="button button_purple button_large">See Team Pricing</a>
+    <div class="team-app-cta">
+      <a href="/teams/" class="button button_purple button_large">See Team Pricing</a>
+    </div>
   </div>
 </section>
 
@@ -470,6 +528,14 @@
     <div class="section-eyebrow"><i class="fa-solid fa-database"></i> How it works</div>
     <h2 class="section-title">SQL runs live — no install, nothing to configure</h2>
     <p class="section-sub">Every lesson connects to a real PostgreSQL 17 database we run and maintain — full schema, full dataset, every extension the book uses. It's a shared, read-only connection: query freely, explore the plans, nothing to break.</p>
+
+    <div class="live-db-cta">
+      <p>Try it yourself, create a free account now</p>
+      <form method="get" action="{{ if hugo.IsServer }}http://api.taop.localhost:8081{{ else }}https://api.theartofpostgresql.com{{ end }}/login">
+        <input type="email" name="email" required placeholder="you@example.com" autocomplete="email" aria-label="Email address">
+        <button type="submit">Get Started</button>
+      </form>
+    </div>
   </div>
 </section>
 

--- a/layouts/page/app.html
+++ b/layouts/page/app.html
@@ -148,7 +148,7 @@
     margin: 0 auto;
     padding: 0 20px 64px;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
     gap: 24px;
     text-align: left;
   }
@@ -175,6 +175,9 @@
     margin: 0;
     padding: 0;
     line-height: 1.6;
+  }
+  @media (max-width: 760px) {
+    .app-features { grid-template-columns: 1fr; }
   }
 
   /* ── Live database section ──────────────────────────────── */

--- a/layouts/page/app.html
+++ b/layouts/page/app.html
@@ -142,7 +142,6 @@
     max-width: 820px;
     margin: 0 auto;
     padding: 72px 20px 0;
-    text-align: center;
   }
   .app-features {
     max-width: 1060px;
@@ -296,7 +295,7 @@
 
   /* ── Dashboard: exercises, quizzes, leaderboard ─────────── */
   .dashboard-section {
-    background: #fff;
+    background: #f8f7f9;
     padding: 72px 20px;
     border-top: 1px solid #ede8f5;
     border-bottom: 1px solid #ede8f5;
@@ -309,12 +308,13 @@
     text-align: left;
   }
   .dash-feature {
-    background: #f8f7f9;
+    background: #fff;
     border-radius: 8px;
     padding: 24px 22px;
   }
-  .dash-feature i { font-size: 1.3rem; color: #60b2d3; margin-bottom: 12px; display: block; }
-  .dash-feature h4 { font: 700 1rem/1.3 'Lato', sans-serif; color: #372649; margin: 0 0 8px; }
+  .dash-feature-head { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
+  .dash-feature i { font-size: 1.3rem; color: #60b2d3; }
+  .dash-feature h4 { font: 700 1rem/1.3 'Lato', sans-serif; color: #372649; margin: 0; font-variant: small-caps; }
   .dash-feature p { font-size: .89rem; color: #67527a; line-height: 1.6; margin: 0; }
   @media (max-width: 760px) {
     .dash-features { grid-template-columns: 1fr; }
@@ -325,7 +325,6 @@
     background: #f8f7f9;
     padding: 72px 20px;
     border-bottom: 1px solid #ede8f5;
-    text-align: center;
   }
   .team-app-inner { max-width: 780px; margin: 0 auto; }
   .team-app-list {
@@ -425,18 +424,15 @@
 
     <div class="dash-features">
       <div class="dash-feature">
-        <i class="fa-solid fa-flask"></i>
-        <h4>Hands-on exercises</h4>
+        <div class="dash-feature-head"><i class="fa-solid fa-flask"></i><h4>Hands-on exercises</h4></div>
         <p>Real SQL problems tied to the chapter or module you just read — run your own query against the same live database and compare it to the reference solution.</p>
       </div>
       <div class="dash-feature">
-        <i class="fa-solid fa-list-check"></i>
-        <h4>Short quizzes</h4>
+        <div class="dash-feature-head"><i class="fa-solid fa-list-check"></i><h4>Short quizzes</h4></div>
         <p>A handful of questions per chapter or module to check what stuck — not graded homework, just a quick gut check.</p>
       </div>
       <div class="dash-feature">
-        <i class="fa-solid fa-trophy"></i>
-        <h4>Leaderboard (optional)</h4>
+        <div class="dash-feature-head"><i class="fa-solid fa-trophy"></i><h4>Leaderboard (optional)</h4></div>
         <p>Points from exercises and quizzes, if you want to track them — opt-in, visible only if you choose to show it.</p>
       </div>
     </div>

--- a/layouts/page/app.html
+++ b/layouts/page/app.html
@@ -286,6 +286,65 @@
   }
   .access-free-note a { color: #372649; font-weight: 700; }
   .access-free-note a:hover { color: #60b2d3; }
+
+  /* ── Dashboard: exercises, quizzes, leaderboard ─────────── */
+  .dashboard-section {
+    background: #fff;
+    padding: 72px 20px;
+    border-top: 1px solid #ede8f5;
+    border-bottom: 1px solid #ede8f5;
+  }
+  .dashboard-inner { max-width: 960px; margin: 0 auto; }
+  .dash-features {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
+    text-align: left;
+  }
+  .dash-feature {
+    background: #f8f7f9;
+    border-radius: 8px;
+    padding: 24px 22px;
+  }
+  .dash-feature i { font-size: 1.3rem; color: #60b2d3; margin-bottom: 12px; display: block; }
+  .dash-feature h4 { font: 700 1rem/1.3 'Lato', sans-serif; color: #372649; margin: 0 0 8px; }
+  .dash-feature p { font-size: .89rem; color: #67527a; line-height: 1.6; margin: 0; }
+  @media (max-width: 760px) {
+    .dash-features { grid-template-columns: 1fr; }
+  }
+
+  /* ── Team dashboard ──────────────────────────────────────── */
+  .team-app-section {
+    background: #f8f7f9;
+    padding: 72px 20px;
+    border-bottom: 1px solid #ede8f5;
+    text-align: center;
+  }
+  .team-app-inner { max-width: 780px; margin: 0 auto; }
+  .team-app-list {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 14px;
+    margin: 8px 0 36px;
+  }
+  .team-app-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 18px 12px;
+    background: #fff;
+    border: 1px solid #ede8f5;
+    border-radius: 8px;
+  }
+  .team-app-item i { font-size: 1.15rem; color: #60b2d3; }
+  .team-app-item span { font-size: .84rem; color: #372649; line-height: 1.3; }
+  @media (max-width: 640px) {
+    .team-app-list { grid-template-columns: repeat(2, 1fr); }
+  }
+  @media (max-width: 420px) {
+    .team-app-list { grid-template-columns: 1fr; }
+  }
   </style>
 </head>
 <body class="page app-page">
@@ -484,6 +543,53 @@
         </tr>
       </tbody>
     </table>
+  </div>
+</section>
+
+<!-- Dashboard: exercises, quizzes, leaderboard -->
+<section class="dashboard-section">
+  <div class="dashboard-inner">
+    <div class="section-eyebrow"><i class="fa-solid fa-chart-line"></i> Track your progress</div>
+    <h2 class="section-title">Your dashboard: chapters, exercises, and quizzes</h2>
+    <p class="section-sub">Every chapter and module comes with hands-on exercises and short quizzes to check what actually stuck — not just a progress bar. Your dashboard tracks what you've read, what you've solved, and what's left.</p>
+
+    <div class="dash-features">
+      <div class="dash-feature">
+        <i class="fa-solid fa-flask"></i>
+        <h4>Hands-on exercises</h4>
+        <p>Real SQL problems tied to the chapter or module you just read — run your own query against the same live database and compare it to the reference solution.</p>
+      </div>
+      <div class="dash-feature">
+        <i class="fa-solid fa-list-check"></i>
+        <h4>Short quizzes</h4>
+        <p>A handful of questions per chapter or module to check what stuck — not graded homework, just a quick gut check.</p>
+      </div>
+      <div class="dash-feature">
+        <i class="fa-solid fa-trophy"></i>
+        <h4>Leaderboard (optional)</h4>
+        <p>Points from exercises and quizzes, if you want to track them — opt-in, visible only if you choose to show it.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Team dashboard -->
+<section class="team-app-section">
+  <div class="team-app-inner">
+    <div class="section-eyebrow"><i class="fa-solid fa-users"></i> Managing a team?</div>
+    <h2 class="section-title">An Enterprise dashboard, layered on top</h2>
+    <p class="section-sub">Buying for your team adds an Enterprise dashboard to the same app — on top of your own student dashboard, not a separate tool.</p>
+
+    <div class="team-app-list">
+      <div class="team-app-item"><i class="fa-solid fa-sitemap"></i><span>Create &amp; manage teams</span></div>
+      <div class="team-app-item"><i class="fa-solid fa-file-csv"></i><span>Add members via form or CSV</span></div>
+      <div class="team-app-item"><i class="fa-solid fa-user-check"></i><span>Assign &amp; reassign seats</span></div>
+      <div class="team-app-item"><i class="fa-solid fa-envelope-open-text"></i><span>Magic-link invites</span></div>
+      <div class="team-app-item"><i class="fa-solid fa-chart-line"></i><span>Per-member progress</span></div>
+      <div class="team-app-item"><i class="fa-solid fa-trophy"></i><span>Team leaderboard</span></div>
+    </div>
+
+    <a href="/teams/" class="button button_purple button_large">See Team Pricing</a>
   </div>
 </section>
 

--- a/layouts/page/app.html
+++ b/layouts/page/app.html
@@ -139,14 +139,14 @@
 
   /* ── Feature tiles ──────────────────────────────────────── */
   .app-features-section {
-    max-width: 820px;
-    margin: 0 auto;
-    padding: 72px 20px 0;
+    background: #fff;
+    padding: 72px 20px 64px;
   }
+  .app-features-inner { max-width: 820px; margin: 0 auto; }
   .app-features {
     max-width: 1060px;
-    margin: 0 auto;
-    padding: 0 20px 64px;
+    margin: 32px auto 0;
+    padding: 0 20px;
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 24px;
@@ -231,10 +231,10 @@
 
   /* ── Comparison table ───────────────────────────────────── */
   .compare-section {
-    max-width: 960px;
-    margin: 0 auto;
+    background: #fff;
     padding: 72px 20px;
   }
+  .compare-inner { max-width: 960px; margin: 0 auto; }
   .compare-table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
   .compare-table {
     width: 100%;
@@ -380,9 +380,11 @@
 
 <!-- Features -->
 <section class="app-features-section">
-  <div class="section-eyebrow"><i class="fa-solid fa-star"></i> Everything in one place</div>
-  <h2 class="section-title">One App for the Book, the Courses, and Live SQL</h2>
-  <p class="section-sub">Read, practice, and track your progress without juggling separate tools, accounts, or installs.</p>
+  <div class="app-features-inner">
+    <div class="section-eyebrow"><i class="fa-solid fa-star"></i> Everything in one place</div>
+    <h2 class="section-title">One App for the Book, the Courses, and Live SQL</h2>
+    <p class="section-sub">Read, practice, and track your progress without juggling separate tools, accounts, or installs.</p>
+  </div>
 
   <div class="app-features">
   <div class="feat-card">
@@ -491,6 +493,7 @@
 
 <!-- Comparison table -->
 <section class="compare-section">
+  <div class="compare-inner">
   <div class="section-eyebrow">How it compares</div>
   <h2 class="section-title">Interactive SQL learning: the landscape</h2>
   <p class="section-sub">Several platforms let you write SQL in a browser. Here is how they differ from the TAOP app's approach.</p>
@@ -582,6 +585,7 @@
         </tr>
       </tbody>
     </table>
+  </div>
   </div>
 </section>
 

--- a/layouts/page/app.html
+++ b/layouts/page/app.html
@@ -315,8 +315,8 @@
     border-radius: 8px;
     padding: 24px 22px;
   }
-  .dash-feature-head { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
-  .dash-feature i { font-size: 1.3rem; color: #60b2d3; }
+  .dash-feature-head { display: flex; align-items: flex-start; gap: 10px; margin-bottom: 8px; }
+  .dash-feature i { font-size: 1.3rem; line-height: 1.3; color: #60b2d3; }
   .dash-feature h4 { font: 700 1rem/1.3 'Lato', sans-serif; color: #372649; margin: 0; font-variant: small-caps; }
   .dash-feature p { font-size: .89rem; color: #67527a; line-height: 1.6; margin: 0; }
   @media (max-width: 760px) {

--- a/layouts/page/teams.html
+++ b/layouts/page/teams.html
@@ -275,7 +275,7 @@
           <table class="price_features_table">
             <tr><td class="icon"><i class="fa-solid fa-users"></i></td><td>5 Architect course seats included, annual</td></tr>
             <tr><td class="icon"><i class="fa-solid fa-user-plus"></i></td><td>Additional seats: $399/seat/year, same flat rate</td></tr>
-            <tr><td class="icon"><i class="fa-solid fa-chalkboard-user"></i></td><td>Optional add-on: Masterclass Curriculum (6 live sessions), $1,495/seat</td></tr>
+            <tr><td class="icon"><i class="fa-solid fa-chalkboard-user"></i></td><td>Optional add-on: Masterclass Curriculum (6 live sessions), $1,495 per team member — add as many as you want, now or later</td></tr>
             <tr><td class="icon"><i class="fa-solid fa-video"></i></td><td>Optional add-on: 3h Office Hours video call with Dimitri Fontaine</td></tr>
             <tr><td class="icon"><i class="fa-solid fa-book"></i></td><td>The Art of PostgreSQL book included for every seat</td></tr>
             <tr><td class="icon"><i class="fa-solid fa-gauge"></i></td><td>Enterprise dashboard: manage members, seats, and progress</td></tr>
@@ -319,7 +319,8 @@
     </div>
 
     <p class="teams_masterclass_cta">
-      $1,495/seat, at checkout or later from your dashboard —
+      $1,495 per team member — add as many as you want, now or later
+      from your dashboard —
       <a href="/masterclass/">see the full curriculum →</a>
     </p>
   </div>
@@ -352,7 +353,7 @@
         <div class="value_item">
           <span class="value_icon"><i class="fa-solid fa-user-check"></i></span>
           <h6>Assign &amp; Reassign Seats</h6>
-          <p>Architect course and optional Masterclass Curriculum seats, assigned at creation or anytime later from your dashboard.</p>
+          <p>Architect course seats, plus optional Masterclass Curriculum access for as many team members as you want — assigned at creation or anytime later from your dashboard.</p>
         </div>
       </li>
       <li>
@@ -397,7 +398,7 @@
       <li>
         <div class="faq_item">
           <h6>Can we add the Masterclass Curriculum too?</h6>
-          <p>Yes — $1,495/seat, at checkout or later from your dashboard. It's especially good value as a team: everyone attends the same live sessions together, as a cohort, and comes back with a shared vocabulary for the codebase.</p>
+          <p>Yes — $1,495 per team member, at checkout or later from your dashboard. Add it for everyone or just a few — it doesn't have to be the whole team. It's especially good value as a group: whoever attends goes through the same six live sessions together, as a cohort, and comes back with a shared vocabulary for the codebase.</p>
         </div>
       </li>
       <li>

--- a/layouts/page/teams.html
+++ b/layouts/page/teams.html
@@ -143,7 +143,7 @@
   <i class="fa-solid fa-users teams-hero-ghost"></i>
   <div class="teams-hero-content">
     <div class="teams-hero-eyebrow">For Teams</div>
-    <h1>PostgreSQL Expertise For Your Whole Team</h1>
+    <h1>PostgreSQL Expertise <br />For Your Whole Team</h1>
     <p>Your whole team gets the same book, course, and hands-on practice, under one purchase — one invite email each, and nothing to install or remember.</p>
     <div class="teams-hero-ctas">
       <a href="https://sales.theartofpostgresql.com/the-art-of-postgresql-team/" class="button button_large">Get Started — $1,995</a>

--- a/layouts/page/teams.html
+++ b/layouts/page/teams.html
@@ -28,7 +28,7 @@
 	  /* ── Hero (bespoke — everything below this reuses shared site styles) ── */
 	  .teams-hero-wrap {
 	    position: relative;
-	    min-height: 90vh;
+	    min-height: 100vh;
 	    overflow: hidden;
 	    background: #181224;
 	  }
@@ -56,7 +56,7 @@
 	  .teams-hero-content {
 	    position: relative;
 	    z-index: 2;
-	    min-height: 90vh;
+	    min-height: 100vh;
 	    max-width: 720px;
 	    margin: 0 auto;
 	    padding: 0 24px;
@@ -99,6 +99,11 @@
 	    .teams-hero-ctas .button { text-align: center; }
 	  }
 
+	  .teams_onboarding {
+	    padding: 80px 0;
+	    background: #fff;
+	  }
+
 	  /* ── same nowrap-on-desktop treatment index/system.html already uses ── */
 	  @media (min-width: 769px) {
 	    .system_flow { flex-wrap: nowrap; gap: 8px; }
@@ -109,12 +114,19 @@
 	    .system_item p { font-size: 12px; }
 	  }
 
-	  /* ── single package card: "Custom" replaces the usual big digit price ── */
+	  /* ── single package card ── */
 	  .price_list.price_list-single { justify-content: center; }
 	  .price_list.price_list-single > li { max-width: 480px; flex-basis: 480px; }
-	  .teams-price-custom {
-	    font: 700 2.2rem/1 'Lato', sans-serif;
-	    color: #372649;
+
+	  /* ── 6 dashboard-feature items read better as 2 rows of 3 than 4+2 ── */
+	  body.teams .book_core_value .value_list {
+	    grid-template-columns: repeat(3, 1fr);
+	  }
+	  @media (max-width: 900px) {
+	    body.teams .book_core_value .value_list { grid-template-columns: repeat(2, 1fr); }
+	  }
+	  @media (max-width: 560px) {
+	    body.teams .book_core_value .value_list { grid-template-columns: 1fr; }
 	  }
 	</style>
 
@@ -132,13 +144,13 @@
   <div class="teams-hero-content">
     <div class="teams-hero-eyebrow">For Teams</div>
     <h1>The Art of PostgreSQL, licensed for your whole team</h1>
-    <p>One annual package: 5 seats of the Architect course included, add more teammates anytime, and optionally add the Masterclass Curriculum. One dashboard, one invite email per teammate, no passwords.</p>
+    <p>One annual package: 5 seats of the Architect course included, add more teammates anytime, and optionally add the Masterclass Curriculum. One Enterprise dashboard, one invite email per teammate, no passwords.</p>
     <div class="teams-hero-ctas">
-      <a href="#pricing" class="button button_large">See Team Pricing</a>
-      <a href="mailto:dim@tapoueh.org?subject=Team%20license%20inquiry" class="button button_large"
+      <a href="https://sales.theartofpostgresql.com/the-art-of-postgresql-team/" class="button button_large">Get Started — $1,995</a>
+      <a href="#pricing" class="button button_large"
          style="background:transparent;border-color:rgba(255,255,255,.4);color:rgba(255,255,255,.85);"
          onmouseover="this.style.background='rgba(255,255,255,.1)';this.style.borderColor='rgba(255,255,255,.7)';this.style.color='#fff'"
-         onmouseout="this.style.background='transparent';this.style.borderColor='rgba(255,255,255,.4)';this.style.color='rgba(255,255,255,.85)'">Talk to Us</a>
+         onmouseout="this.style.background='transparent';this.style.borderColor='rgba(255,255,255,.4)';this.style.color='rgba(255,255,255,.85)'">See What's Included</a>
     </div>
   </div>
 </div>
@@ -148,20 +160,20 @@
   <div class="wrapper">
     <header class="heading">
       <h3>Add your team in four steps</h3>
-      <p class="lightpurple">No procurement call, no admin training — it's an email list, not a new tool to learn.</p>
+      <p class="lightpurple">No procurement call, no admin training — it's an Enterprise dashboard in the app, on top of the regular student dashboard, not a new tool to learn.</p>
     </header>
 
     <div class="system_flow">
       <div class="system_item">
         <span class="system_icon"><i class="fa-solid fa-credit-card"></i></span>
         <h6>Buy</h6>
-        <p>Annual, 5 Architect seats included</p>
+        <p>Self-serve checkout, 5 Architect seats included</p>
       </div>
       <span class="system_arrow"><i class="fa-solid fa-arrow-right"></i></span>
       <div class="system_item">
         <span class="system_icon"><i class="fa-solid fa-users"></i></span>
         <h6>Add your team</h6>
-        <p>A form, or upload a CSV</p>
+        <p>From the Enterprise dashboard: a form, or upload a CSV</p>
       </div>
       <span class="system_arrow"><i class="fa-solid fa-arrow-right"></i></span>
       <div class="system_item">
@@ -195,24 +207,28 @@
         <div>
           <div class="best">TEAM PACKAGE</div>
           <h5>Architect Course — Team</h5>
-          <div class="price teams-price-custom">Custom</div>
-          <p class="tier-subtitle">5 seats included, annual, add more anytime</p>
+          <div class="price"><sup>$</sup>1,995</div>
+          <p class="paid_yearly">per year, 5 seats included</p>
+          <p class="tier-subtitle">$399/seat — a discount over the $449/seat individual price</p>
           <p>
             The full Architect course for your team — the same
             system-design depth (schemas, partitioning, scale) as the
-            individual Architect tier, licensed for 5 teammates to start.
+            individual Architect tier, licensed for 5 teammates to
+            start. Buying as a team saves $250 over 5 individual
+            Architect seats, and every seat after that stays at the
+            same $399/seat rate — no volume tiers to negotiate.
           </p>
           <table class="price_features_table">
             <tr><td class="icon"><i class="fa-solid fa-users"></i></td><td>5 Architect course seats included, annual</td></tr>
-            <tr><td class="icon"><i class="fa-solid fa-user-plus"></i></td><td>Add more seats anytime, same per-seat rate</td></tr>
-            <tr><td class="icon"><i class="fa-solid fa-chalkboard-user"></i></td><td>Optional add-on: Masterclass Curriculum seats, any quantity</td></tr>
+            <tr><td class="icon"><i class="fa-solid fa-user-plus"></i></td><td>Additional seats: $399/seat/year, same flat rate</td></tr>
+            <tr><td class="icon"><i class="fa-solid fa-chalkboard-user"></i></td><td>Optional add-on: Masterclass Curriculum, $1,495/seat</td></tr>
             <tr><td class="icon"><i class="fa-solid fa-video"></i></td><td>Optional add-on: 3h Office Hours video call with Dimitri Fontaine</td></tr>
             <tr><td class="icon"><i class="fa-solid fa-book"></i></td><td>The Art of PostgreSQL book included for every seat</td></tr>
-            <tr><td class="icon"><i class="fa-solid fa-gauge"></i></td><td>Team dashboard: manage members, seats, and progress</td></tr>
+            <tr><td class="icon"><i class="fa-solid fa-gauge"></i></td><td>Enterprise dashboard: manage members, seats, and progress</td></tr>
           </table>
           <div class="price_cta">
             {{ partial "money-back-guarantee.html" . }}
-            <a class="button button_purple" href="mailto:dim@tapoueh.org?subject=Team%20license%20inquiry">Talk to Us</a>
+            <a class="button button_purple" href="https://sales.theartofpostgresql.com/the-art-of-postgresql-team/">Get Started — $1,995</a>
           </div>
         </div>
       </li>
@@ -220,9 +236,12 @@
 
     <header class="heading">
       <p class="lightpurple">
-        Pricing depends on your team size and add-ons — we quote it
-        directly rather than publish a flat rate.
-        <a href="mailto:dim@tapoueh.org?subject=Team%20license%20inquiry" style="color:#fff;font-weight:700;text-decoration:underline;">Talk to us <i class="fa-solid fa-arrow-right" style="font-size:.75em;"></i></a>
+        Attending the Masterclass Curriculum as a team, live, together?
+        That's where it earns its price — a shared cohort experience,
+        the same six live sessions, the same real-time Q&amp;A, and a
+        common vocabulary to bring back to your codebase. Add it for
+        any teammate at $1,495/seat, at checkout or later from your
+        dashboard.
       </p>
     </header>
   </div>
@@ -232,16 +251,23 @@
 <div class="book_core_value">
   <div class="wrapper">
     <header class="heading">
-      <h3>One Dashboard for the Whole Team</h3>
-      <p class="lightpurple">Built for whoever owns the purchase, not for IT</p>
+      <h3>One Enterprise Dashboard for the Whole Team</h3>
+      <p class="lightpurple">Built into the app, layered on top of your own student dashboard — not a separate tool to log into</p>
     </header>
 
     <ul class="value_list">
       <li>
         <div class="value_item">
+          <span class="value_icon"><i class="fa-solid fa-sitemap"></i></span>
+          <h6>Create &amp; Manage Teams</h6>
+          <p>Teams default to your department name, and you can create as many as you need — organize seats the way your company actually works.</p>
+        </div>
+      </li>
+      <li>
+        <div class="value_item">
           <span class="value_icon"><i class="fa-solid fa-file-csv"></i></span>
           <h6>Add Members Your Way</h6>
-          <p>Fill a form or upload a CSV. Teams default to your department name, and you can create as many as you need.</p>
+          <p>Fill a form or upload a CSV to add a whole team at once.</p>
         </div>
       </li>
       <li>
@@ -260,9 +286,16 @@
       </li>
       <li>
         <div class="value_item">
+          <span class="value_icon"><i class="fa-solid fa-chart-line"></i></span>
+          <h6>Per-Member Progress</h6>
+          <p>See exactly where each teammate stands — chapters read, points earned, Core through Architect.</p>
+        </div>
+      </li>
+      <li>
+        <div class="value_item">
           <span class="value_icon"><i class="fa-solid fa-trophy"></i></span>
-          <h6>Team Progress &amp; Leaderboard</h6>
-          <p>See chapters read and points earned across the team, Core through Architect, with a team leaderboard.</p>
+          <h6>Team Leaderboard</h6>
+          <p>Aggregate scores by team or department, and see individual standings side by side.</p>
         </div>
       </li>
     </ul>
@@ -279,14 +312,14 @@
     <ul class="faq_list">
       <li>
         <div class="faq_item">
-          <h6>How many seats are included?</h6>
-          <p>The base annual package includes 5 Architect course seats. Add more teammates anytime from your dashboard, at the same per-seat rate.</p>
+          <h6>How many seats are included, and what does it cost?</h6>
+          <p>The $1,995/year package includes 5 Architect course seats — $399/seat, a discount over the $449/seat individual price. Add more teammates anytime at the same $399/seat flat rate, no volume tiers to negotiate.</p>
         </div>
       </li>
       <li>
         <div class="faq_item">
           <h6>Can we add the Masterclass Curriculum too?</h6>
-          <p>Yes — it's an optional add-on with its own seat count, assignable from your dashboard alongside your course seats.</p>
+          <p>Yes — $1,495/seat, at checkout or later from your dashboard. It's especially good value as a team: everyone attends the same live sessions together, as a cohort, and comes back with a shared vocabulary for the codebase.</p>
         </div>
       </li>
       <li>
@@ -328,10 +361,10 @@
   <div class="wrapper">
     <header class="heading">
       <h3>Ready to License Your Team?</h3>
-      <p class="lightpurple">Tell us your team size and we'll get you set up.</p>
+      <p class="lightpurple">5 Architect seats included, add more anytime — set up your team today.</p>
     </header>
     <div class="cta_buttons">
-      <a href="mailto:dim@tapoueh.org?subject=Team%20license%20inquiry" class="button button_purple button_large">Talk to Us</a>
+      <a href="https://sales.theartofpostgresql.com/the-art-of-postgresql-team/" class="button button_purple button_large">Get Started — $1,995</a>
     </div>
   </div>
 </div>

--- a/layouts/page/teams.html
+++ b/layouts/page/teams.html
@@ -4,14 +4,14 @@
 	<meta charset="utf-8">
 	<title>The Art of PostgreSQL for Teams</title>
 	<link rel="canonical" href="{{ .Permalink }}">
-	<meta name="description" content="License the Architect course for your team — 5 seats included, add more anytime, optionally add the Masterclass Curriculum. One dashboard to manage your whole team, no passwords.">
+	<meta name="description" content="The Architect course for your whole team, under one purchase — buy exactly as many seats as your team needs, optionally add the Masterclass Curriculum. One dashboard, no passwords.">
 
 	<meta name="twitter:card" content="summary" />
 	<meta name="twitter:site" content="@tapoueh" />
 	<meta name="twitter:creator" content="@tapoueh" />
 	<meta property="og:url" content="{{ .Permalink }}" />
 	<meta property="og:title" content="The Art of PostgreSQL for Teams" />
-	<meta property="og:description" content="One annual package: 5 Architect course seats included, add more anytime, optional Masterclass Curriculum add-on. One dashboard, no passwords." />
+	<meta property="og:description" content="PostgreSQL expertise for your whole team — the book, the course, and hands-on practice, under one purchase. Optional Masterclass Curriculum add-on. One dashboard, no passwords." />
 	<meta property="og:image" content="https://theartofpostgresql.com/images/hardcover-mockup.jpg" />
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
@@ -143,8 +143,8 @@
   <i class="fa-solid fa-users teams-hero-ghost"></i>
   <div class="teams-hero-content">
     <div class="teams-hero-eyebrow">For Teams</div>
-    <h1>The Art of PostgreSQL, licensed for your whole team</h1>
-    <p>One annual package: 5 seats of the Architect course included, add more teammates anytime, and optionally add the Masterclass Curriculum. One Enterprise dashboard, one invite email per teammate, no passwords.</p>
+    <h1>PostgreSQL Expertise For Your Whole Team</h1>
+    <p>Your whole team gets the same book, course, and hands-on practice, under one purchase — one invite email each, and nothing to install or remember.</p>
     <div class="teams-hero-ctas">
       <a href="https://sales.theartofpostgresql.com/the-art-of-postgresql-team/" class="button button_large">Get Started — $1,995</a>
       <a href="#pricing" class="button button_large"
@@ -213,10 +213,12 @@
           <p>
             The full Architect course for your team — the same
             system-design depth (schemas, partitioning, scale) as the
-            individual Architect tier, licensed for 5 teammates to
-            start. Buying as a team saves $250 over 5 individual
-            Architect seats, and every seat after that stays at the
-            same $399/seat rate — no volume tiers to negotiate.
+            individual Architect tier. Five seats is simply where the
+            team package starts — a minimum to open the deal, not a
+            recommended team size — so buy exactly as many as your
+            team actually needs. Those first 5 already save you $250
+            over the individual price, and every seat after that stays
+            at the same $399/seat rate — no volume tiers to negotiate.
           </p>
           <table class="price_features_table">
             <tr><td class="icon"><i class="fa-solid fa-users"></i></td><td>5 Architect course seats included, annual</td></tr>

--- a/layouts/page/teams.html
+++ b/layouts/page/teams.html
@@ -160,7 +160,7 @@
   <div class="wrapper">
     <header class="heading">
       <h3>Add your team in four steps</h3>
-      <p class="lightpurple">No procurement call, no admin training — it's an Enterprise dashboard in the app, on top of the regular student dashboard, not a new tool to learn.</p>
+      <p class="lightpurple">No procurement call, no admin training — it's an Enterprise dashboard already built into the app, on top of your regular student dashboard.</p>
     </header>
 
     <div class="system_flow">
@@ -221,7 +221,7 @@
           <table class="price_features_table">
             <tr><td class="icon"><i class="fa-solid fa-users"></i></td><td>5 Architect course seats included, annual</td></tr>
             <tr><td class="icon"><i class="fa-solid fa-user-plus"></i></td><td>Additional seats: $399/seat/year, same flat rate</td></tr>
-            <tr><td class="icon"><i class="fa-solid fa-chalkboard-user"></i></td><td>Optional add-on: Masterclass Curriculum, $1,495/seat</td></tr>
+            <tr><td class="icon"><i class="fa-solid fa-chalkboard-user"></i></td><td>Optional add-on: Masterclass Curriculum (6 live sessions), $1,495/seat</td></tr>
             <tr><td class="icon"><i class="fa-solid fa-video"></i></td><td>Optional add-on: 3h Office Hours video call with Dimitri Fontaine</td></tr>
             <tr><td class="icon"><i class="fa-solid fa-book"></i></td><td>The Art of PostgreSQL book included for every seat</td></tr>
             <tr><td class="icon"><i class="fa-solid fa-gauge"></i></td><td>Enterprise dashboard: manage members, seats, and progress</td></tr>
@@ -236,12 +236,16 @@
 
     <header class="heading">
       <p class="lightpurple">
-        Attending the Masterclass Curriculum as a team, live, together?
-        That's where it earns its price — a shared cohort experience,
-        the same six live sessions, the same real-time Q&amp;A, and a
-        common vocabulary to bring back to your codebase. Add it for
-        any teammate at $1,495/seat, at checkout or later from your
-        dashboard.
+        The Masterclass Curriculum isn't a single session — it's the
+        full six-session series, live, covering the topics that come
+        up on every team: aggregation and reporting, window functions,
+        reading query plans, advanced joins, schema design, and query
+        optimization. Attending as a team, together, is where it earns
+        its price — a shared cohort experience and a common vocabulary
+        to bring back to your codebase, not six people who happened to
+        watch the same recordings alone. Add it for any teammate at
+        $1,495/seat, at checkout or later from your dashboard —
+        <a href="/masterclass/" style="color:#372649;font-weight:700;">see the full curriculum →</a>
       </p>
     </header>
   </div>
@@ -252,7 +256,7 @@
   <div class="wrapper">
     <header class="heading">
       <h3>One Enterprise Dashboard for the Whole Team</h3>
-      <p class="lightpurple">Built into the app, layered on top of your own student dashboard — not a separate tool to log into</p>
+      <p class="lightpurple">Built into the app, layered on top of your own student dashboard</p>
     </header>
 
     <ul class="value_list">
@@ -325,7 +329,7 @@
       <li>
         <div class="faq_item">
           <h6>What happens to a seat when someone leaves the company?</h6>
-          <p>If they never logged in, you can fix the assignment and hand that seat to someone else. Once a teammate has actually accessed their content, their access becomes personal — they can even register their own email to keep it — so that specific seat isn't reassignable, but you can always add more.</p>
+          <p>Nothing — it's theirs to keep. The Art of PostgreSQL licenses are lifetime: once a teammate has logged in, that access is personally theirs, even after they leave your company. We'd rather invest in people than in seats. Before their first login, you can still fix a typo or hand the seat to someone else; after that, it's set, and you're always free to add a new seat for their replacement.</p>
         </div>
       </li>
       <li>

--- a/layouts/page/teams.html
+++ b/layouts/page/teams.html
@@ -167,25 +167,25 @@
       <div class="system_item">
         <span class="system_icon"><i class="fa-solid fa-credit-card"></i></span>
         <h6>Buy</h6>
-        <p>Self-serve checkout, 5 Architect seats included</p>
+        <p>Self-serve checkout,<br />5 Architect seats included</p>
       </div>
       <span class="system_arrow"><i class="fa-solid fa-arrow-right"></i></span>
       <div class="system_item">
         <span class="system_icon"><i class="fa-solid fa-users"></i></span>
         <h6>Add your team</h6>
-        <p>From the Enterprise dashboard: a form, or upload a CSV</p>
+        <p>From the Enterprise dashboard:<br />a form, or upload a CSV</p>
       </div>
       <span class="system_arrow"><i class="fa-solid fa-arrow-right"></i></span>
       <div class="system_item">
         <span class="system_icon"><i class="fa-solid fa-envelope"></i></span>
         <h6>Assign &amp; invite</h6>
-        <p>One-time sign-in link each</p>
+        <p>One-time sign-in link<br />each</p>
       </div>
       <span class="system_arrow"><i class="fa-solid fa-arrow-right"></i></span>
       <div class="system_item">
         <span class="system_icon"><i class="fa-solid fa-trophy"></i></span>
         <h6>Track progress</h6>
-        <p>Team leaderboard, Core → Architect</p>
+        <p>Team leaderboard,<br />Core → Architect</p>
       </div>
     </div>
   </div>

--- a/layouts/page/teams.html
+++ b/layouts/page/teams.html
@@ -1,0 +1,356 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>The Art of PostgreSQL for Teams</title>
+	<link rel="canonical" href="{{ .Permalink }}">
+	<meta name="description" content="License the Architect course for your team — 5 seats included, add more anytime, optionally add the Masterclass Curriculum. One dashboard to manage your whole team, no passwords.">
+
+	<meta name="twitter:card" content="summary" />
+	<meta name="twitter:site" content="@tapoueh" />
+	<meta name="twitter:creator" content="@tapoueh" />
+	<meta property="og:url" content="{{ .Permalink }}" />
+	<meta property="og:title" content="The Art of PostgreSQL for Teams" />
+	<meta property="og:description" content="One annual package: 5 Architect course seats included, add more anytime, optional Masterclass Curriculum add-on. One dashboard, no passwords." />
+	<meta property="og:image" content="https://theartofpostgresql.com/images/hardcover-mockup.jpg" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+
+	<link href="/favicon.ico" rel="icon" type="image/x-icon">
+
+	<link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700" rel="stylesheet">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+	<link rel="stylesheet" href="/css/style.css">
+	<style>
+	  body.teams .header { background: transparent; border-bottom-color: transparent; transition: background 0.3s, border-color 0.3s; }
+	  body.teams .header.nav-solid { background: #372649; border-bottom-color: rgba(255,255,255,0.3); }
+
+	  /* ── Hero (bespoke — everything below this reuses shared site styles) ── */
+	  .teams-hero-wrap {
+	    position: relative;
+	    min-height: 90vh;
+	    overflow: hidden;
+	    background: #181224;
+	  }
+	  .teams-hero-wrap > img {
+	    position: absolute;
+	    inset: 0;
+	    width: 100%;
+	    height: 100%;
+	    object-fit: cover;
+	    object-position: center;
+	    z-index: 0;
+	  }
+	  .teams-hero-ghost {
+	    position: absolute;
+	    right: -40px;
+	    top: 50%;
+	    transform: translateY(-50%);
+	    font-size: 440px;
+	    opacity: 0.07;
+	    color: #fff;
+	    line-height: 1;
+	    pointer-events: none;
+	    z-index: 1;
+	  }
+	  .teams-hero-content {
+	    position: relative;
+	    z-index: 2;
+	    min-height: 90vh;
+	    max-width: 720px;
+	    margin: 0 auto;
+	    padding: 0 24px;
+	    display: flex;
+	    flex-flow: column nowrap;
+	    justify-content: center;
+	    align-items: center;
+	    text-align: center;
+	  }
+	  .teams-hero-eyebrow {
+	    font: 700 11px/1 'Lato', sans-serif;
+	    letter-spacing: .14em;
+	    text-transform: uppercase;
+	    color: #60b2d3;
+	    margin-bottom: 22px;
+	  }
+	  .teams-hero-content h1 {
+	    color: #fff;
+	    font: 300 2.9rem/1.15 'Lato', sans-serif;
+	    margin: 0 0 24px;
+	    padding: 0;
+	  }
+	  .teams-hero-content p {
+	    color: rgba(255,255,255,.65);
+	    font-size: 1.1rem;
+	    line-height: 1.65;
+	    max-width: 560px;
+	    margin: 0 0 44px;
+	    padding: 0;
+	  }
+	  .teams-hero-ctas {
+	    display: flex;
+	    gap: 20px;
+	    flex-wrap: wrap;
+	    justify-content: center;
+	  }
+	  @media (max-width: 540px) {
+	    .teams-hero-content h1 { font-size: 2rem; }
+	    .teams-hero-ctas { flex-direction: column; width: 100%; }
+	    .teams-hero-ctas .button { text-align: center; }
+	  }
+
+	  /* ── same nowrap-on-desktop treatment index/system.html already uses ── */
+	  @media (min-width: 769px) {
+	    .system_flow { flex-wrap: nowrap; gap: 8px; }
+	    .system_item { padding: 12px 8px; min-width: 0; }
+	    .system_icon { font-size: 30px; }
+	    .system_arrow { font-size: 16px; }
+	    .system_item h6 { font-size: 14px; }
+	    .system_item p { font-size: 12px; }
+	  }
+
+	  /* ── single package card: "Custom" replaces the usual big digit price ── */
+	  .price_list.price_list-single { justify-content: center; }
+	  .price_list.price_list-single > li { max-width: 480px; flex-basis: 480px; }
+	  .teams-price-custom {
+	    font: 700 2.2rem/1 'Lato', sans-serif;
+	    color: #372649;
+	  }
+	</style>
+
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+	<script src="/js/custom.js"></script>
+</head>
+<body class="teams">
+
+{{ partial "header.html" . }}
+
+<!-- Hero -->
+<div class="teams-hero-wrap">
+  <img src="/images/demo/slide.jpg" alt="">
+  <i class="fa-solid fa-users teams-hero-ghost"></i>
+  <div class="teams-hero-content">
+    <div class="teams-hero-eyebrow">For Teams</div>
+    <h1>The Art of PostgreSQL, licensed for your whole team</h1>
+    <p>One annual package: 5 seats of the Architect course included, add more teammates anytime, and optionally add the Masterclass Curriculum. One dashboard, one invite email per teammate, no passwords.</p>
+    <div class="teams-hero-ctas">
+      <a href="#pricing" class="button button_large">See Team Pricing</a>
+      <a href="mailto:dim@tapoueh.org?subject=Team%20license%20inquiry" class="button button_large"
+         style="background:transparent;border-color:rgba(255,255,255,.4);color:rgba(255,255,255,.85);"
+         onmouseover="this.style.background='rgba(255,255,255,.1)';this.style.borderColor='rgba(255,255,255,.7)';this.style.color='#fff'"
+         onmouseout="this.style.background='transparent';this.style.borderColor='rgba(255,255,255,.4)';this.style.color='rgba(255,255,255,.85)'">Talk to Us</a>
+    </div>
+  </div>
+</div>
+
+<!-- How it works -->
+<div class="teams_onboarding">
+  <div class="wrapper">
+    <header class="heading">
+      <h3>Add your team in four steps</h3>
+      <p class="lightpurple">No procurement call, no admin training — it's an email list, not a new tool to learn.</p>
+    </header>
+
+    <div class="system_flow">
+      <div class="system_item">
+        <span class="system_icon"><i class="fa-solid fa-credit-card"></i></span>
+        <h6>Buy</h6>
+        <p>Annual, 5 Architect seats included</p>
+      </div>
+      <span class="system_arrow"><i class="fa-solid fa-arrow-right"></i></span>
+      <div class="system_item">
+        <span class="system_icon"><i class="fa-solid fa-users"></i></span>
+        <h6>Add your team</h6>
+        <p>A form, or upload a CSV</p>
+      </div>
+      <span class="system_arrow"><i class="fa-solid fa-arrow-right"></i></span>
+      <div class="system_item">
+        <span class="system_icon"><i class="fa-solid fa-envelope"></i></span>
+        <h6>Assign &amp; invite</h6>
+        <p>One-time sign-in link each</p>
+      </div>
+      <span class="system_arrow"><i class="fa-solid fa-arrow-right"></i></span>
+      <div class="system_item">
+        <span class="system_icon"><i class="fa-solid fa-trophy"></i></span>
+        <h6>Track progress</h6>
+        <p>Team leaderboard, Core → Architect</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Pricing -->
+<div id="pricing" class="packages_block">
+  <div class="wrapper">
+    <header class="heading">
+      <h3>Team Pricing</h3>
+      <p class="lightpurple">
+        One annual package for your team, with seats and add-ons you
+        control from the dashboard.
+      </p>
+    </header>
+
+    <ul class="price_list price_list-single">
+      <li class="bestvalue">
+        <div>
+          <div class="best">TEAM PACKAGE</div>
+          <h5>Architect Course — Team</h5>
+          <div class="price teams-price-custom">Custom</div>
+          <p class="tier-subtitle">5 seats included, annual, add more anytime</p>
+          <p>
+            The full Architect course for your team — the same
+            system-design depth (schemas, partitioning, scale) as the
+            individual Architect tier, licensed for 5 teammates to start.
+          </p>
+          <table class="price_features_table">
+            <tr><td class="icon"><i class="fa-solid fa-users"></i></td><td>5 Architect course seats included, annual</td></tr>
+            <tr><td class="icon"><i class="fa-solid fa-user-plus"></i></td><td>Add more seats anytime, same per-seat rate</td></tr>
+            <tr><td class="icon"><i class="fa-solid fa-chalkboard-user"></i></td><td>Optional add-on: Masterclass Curriculum seats, any quantity</td></tr>
+            <tr><td class="icon"><i class="fa-solid fa-video"></i></td><td>Optional add-on: 3h Office Hours video call with Dimitri Fontaine</td></tr>
+            <tr><td class="icon"><i class="fa-solid fa-book"></i></td><td>The Art of PostgreSQL book included for every seat</td></tr>
+            <tr><td class="icon"><i class="fa-solid fa-gauge"></i></td><td>Team dashboard: manage members, seats, and progress</td></tr>
+          </table>
+          <div class="price_cta">
+            {{ partial "money-back-guarantee.html" . }}
+            <a class="button button_purple" href="mailto:dim@tapoueh.org?subject=Team%20license%20inquiry">Talk to Us</a>
+          </div>
+        </div>
+      </li>
+    </ul>
+
+    <header class="heading">
+      <p class="lightpurple">
+        Pricing depends on your team size and add-ons — we quote it
+        directly rather than publish a flat rate.
+        <a href="mailto:dim@tapoueh.org?subject=Team%20license%20inquiry" style="color:#fff;font-weight:700;text-decoration:underline;">Talk to us <i class="fa-solid fa-arrow-right" style="font-size:.75em;"></i></a>
+      </p>
+    </header>
+  </div>
+</div>
+
+<!-- Dashboard features -->
+<div class="book_core_value">
+  <div class="wrapper">
+    <header class="heading">
+      <h3>One Dashboard for the Whole Team</h3>
+      <p class="lightpurple">Built for whoever owns the purchase, not for IT</p>
+    </header>
+
+    <ul class="value_list">
+      <li>
+        <div class="value_item">
+          <span class="value_icon"><i class="fa-solid fa-file-csv"></i></span>
+          <h6>Add Members Your Way</h6>
+          <p>Fill a form or upload a CSV. Teams default to your department name, and you can create as many as you need.</p>
+        </div>
+      </li>
+      <li>
+        <div class="value_item">
+          <span class="value_icon"><i class="fa-solid fa-user-check"></i></span>
+          <h6>Assign &amp; Reassign Seats</h6>
+          <p>Architect course and optional Masterclass Curriculum seats, assigned at creation or anytime later from your dashboard.</p>
+        </div>
+      </li>
+      <li>
+        <div class="value_item">
+          <span class="value_icon"><i class="fa-solid fa-envelope-open-text"></i></span>
+          <h6>Magic-Link Invites</h6>
+          <p>One-time sign-in link per teammate, no passwords — the invite email carries your name, company, and team.</p>
+        </div>
+      </li>
+      <li>
+        <div class="value_item">
+          <span class="value_icon"><i class="fa-solid fa-trophy"></i></span>
+          <h6>Team Progress &amp; Leaderboard</h6>
+          <p>See chapters read and points earned across the team, Core through Architect, with a team leaderboard.</p>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>
+
+<!-- FAQ -->
+<div class="course_faq">
+  <div class="wrapper">
+    <header class="heading">
+      <h3>Frequently Asked Questions</h3>
+    </header>
+
+    <ul class="faq_list">
+      <li>
+        <div class="faq_item">
+          <h6>How many seats are included?</h6>
+          <p>The base annual package includes 5 Architect course seats. Add more teammates anytime from your dashboard, at the same per-seat rate.</p>
+        </div>
+      </li>
+      <li>
+        <div class="faq_item">
+          <h6>Can we add the Masterclass Curriculum too?</h6>
+          <p>Yes — it's an optional add-on with its own seat count, assignable from your dashboard alongside your course seats.</p>
+        </div>
+      </li>
+      <li>
+        <div class="faq_item">
+          <h6>What happens to a seat when someone leaves the company?</h6>
+          <p>If they never logged in, you can fix the assignment and hand that seat to someone else. Once a teammate has actually accessed their content, their access becomes personal — they can even register their own email to keep it — so that specific seat isn't reassignable, but you can always add more.</p>
+        </div>
+      </li>
+      <li>
+        <div class="faq_item">
+          <h6>How does renewal work?</h6>
+          <p>The package runs for one year. A renewal option appears in your team dashboard starting a month before it expires — no surprises, no auto-charges.</p>
+        </div>
+      </li>
+      <li>
+        <div class="faq_item">
+          <h6>Can we get time with the author?</h6>
+          <p>Yes — Office Hours is an optional add-on: a 3-hour video call with Dimitri Fontaine for your team to ask about PostgreSQL, your own queries, or architecture decisions.</p>
+        </div>
+      </li>
+      <li>
+        <div class="faq_item">
+          <h6>We already have an Enterprise Edition book license from the First Edition — does this still work?</h6>
+          <p>Yes. Legacy Enterprise Edition licenses (book only, up to 15 members) work with the same team dashboard — manage your members there, and add course or Masterclass seats as an upgrade whenever you're ready. <a href="/login/">Sign in</a> or <a href="mailto:dim@tapoueh.org?subject=Enterprise%20Edition%20migration">get in touch</a> if you need a hand migrating.</p>
+        </div>
+      </li>
+      <li>
+        <div class="faq_item">
+          <h6>What's your refund policy?</h6>
+          <p>Same as our other products: a full, no-questions-asked refund, even after you've started assigning seats.</p>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>
+
+<!-- Final CTA -->
+<div class="course_final_cta">
+  <div class="wrapper">
+    <header class="heading">
+      <h3>Ready to License Your Team?</h3>
+      <p class="lightpurple">Tell us your team size and we'll get you set up.</p>
+    </header>
+    <div class="cta_buttons">
+      <a href="mailto:dim@tapoueh.org?subject=Team%20license%20inquiry" class="button button_purple button_large">Talk to Us</a>
+    </div>
+  </div>
+</div>
+
+{{ partial "subscribe.html" . }}
+{{ partial "footer.html" . }}
+
+<script>
+(function() {
+  var $header = $('.header');
+  var threshold = window.innerHeight * 0.7;
+  $(window).on('scroll.teamshero', function() {
+    if ($(this).scrollTop() > threshold) {
+      $header.addClass('nav-solid');
+    } else {
+      $header.removeClass('nav-solid');
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/layouts/page/teams.html
+++ b/layouts/page/teams.html
@@ -118,6 +118,58 @@
 	  .price_list.price_list-single { justify-content: center; }
 	  .price_list.price_list-single > li { max-width: 480px; flex-basis: 480px; }
 
+	  /* ── Masterclass Curriculum section ── */
+	  .teams_masterclass {
+	    background: #fff;
+	    padding: 80px 0;
+	    text-align: center;
+	  }
+	  .teams_masterclass .section_icons { color: #60b2d3; }
+	  .teams_masterclass_intro {
+	    max-width: 680px;
+	    margin: 0 auto 36px;
+	    color: #5a4a70;
+	    font: 300 1rem/1.65 'Lato', sans-serif;
+	  }
+	  .teams-mc-topics {
+	    display: grid;
+	    grid-template-columns: repeat(3, 1fr);
+	    gap: 16px;
+	    max-width: 780px;
+	    margin: 0 auto 32px;
+	  }
+	  .teams-mc-topic {
+	    display: flex;
+	    flex-direction: column;
+	    align-items: center;
+	    gap: 10px;
+	    padding: 22px 16px;
+	    background: #f5f2fa;
+	    border-radius: 8px;
+	  }
+	  .teams-mc-topic i {
+	    font-size: 1.3rem;
+	    color: #60b2d3;
+	  }
+	  .teams-mc-topic span {
+	    font: 400 0.88rem/1.3 'Lato', sans-serif;
+	    color: #372649;
+	  }
+	  .teams_masterclass_cta {
+	    color: #5a4a70;
+	    font: 300 1rem/1.6 'Lato', sans-serif;
+	  }
+	  .teams_masterclass_cta a {
+	    color: #372649;
+	    font-weight: 700;
+	  }
+	  @media (max-width: 640px) {
+	    .teams-mc-topics { grid-template-columns: repeat(2, 1fr); }
+	  }
+	  @media (max-width: 420px) {
+	    .teams-mc-topics { grid-template-columns: 1fr; }
+	  }
+
 	  /* ── 6 dashboard-feature items read better as 2 rows of 3 than 4+2 ── */
 	  body.teams .book_core_value .value_list {
 	    grid-template-columns: repeat(3, 1fr);
@@ -236,20 +288,40 @@
       </li>
     </ul>
 
+  </div>
+</div>
+
+<!-- Masterclass Curriculum -->
+<div class="teams_masterclass">
+  <div class="wrapper">
+    <div class="section_icons">
+      <span class="system_icon"><i class="fa-solid fa-chalkboard-user"></i></span>
+    </div>
     <header class="heading">
-      <p class="lightpurple">
-        The Masterclass Curriculum isn't a single session — it's the
-        full six-session series, live, covering the topics that come
-        up on every team: aggregation and reporting, window functions,
-        reading query plans, advanced joins, schema design, and query
-        optimization. Attending as a team, together, is where it earns
-        its price — a shared cohort experience and a common vocabulary
-        to bring back to your codebase, not six people who happened to
-        watch the same recordings alone. Add it for any teammate at
-        $1,495/seat, at checkout or later from your dashboard —
-        <a href="/masterclass/" style="color:#372649;font-weight:700;">see the full curriculum →</a>
-      </p>
+      <h3>The Masterclass Curriculum, As a Team</h3>
+      <p class="lightpurple">Six live sessions, together — not six people watching alone</p>
     </header>
+    <p class="teams_masterclass_intro">
+      The Masterclass Curriculum isn't a single session — it's the
+      full six-session series, live, covering the topics that come up
+      on every team. Attending together is where it earns its price —
+      a shared cohort experience and a common vocabulary to bring back
+      to your codebase.
+    </p>
+
+    <div class="teams-mc-topics">
+      <div class="teams-mc-topic"><i class="fa-solid fa-chart-pie"></i><span>Reliable Aggregations</span></div>
+      <div class="teams-mc-topic"><i class="fa-solid fa-chart-line"></i><span>Master Window Functions</span></div>
+      <div class="teams-mc-topic"><i class="fa-solid fa-diagram-project"></i><span>Read Query Plans</span></div>
+      <div class="teams-mc-topic"><i class="fa-solid fa-code-branch"></i><span>Advanced JOIN Patterns</span></div>
+      <div class="teams-mc-topic"><i class="fa-solid fa-sitemap"></i><span>Schema for Performance</span></div>
+      <div class="teams-mc-topic"><i class="fa-solid fa-gauge-high"></i><span>Optimize SQL Performance</span></div>
+    </div>
+
+    <p class="teams_masterclass_cta">
+      $1,495/seat, at checkout or later from your dashboard —
+      <a href="/masterclass/">see the full curriculum →</a>
+    </p>
   </div>
 </div>
 

--- a/layouts/partials/course/pricing.html
+++ b/layouts/partials/course/pricing.html
@@ -122,6 +122,7 @@
     <header class="heading">
       <div class="cta_row">
         <a href="#curriculum" class="button button_transparent">View Full Curriculum</a>
+        <a href="/teams/" class="button button_transparent" style="margin-left:15px;">Enroll Your Team</a>
       </div>
     </header>
   </div>

--- a/layouts/partials/index/teams.html
+++ b/layouts/partials/index/teams.html
@@ -1,0 +1,26 @@
+<div class="index_workshops">
+  <div class="wrapper">
+    <header class="heading">
+      <h3>PostgreSQL Expertise For Your Whole Team</h3>
+      <p class="lightpurple">
+        One Architect course package, per-member pricing, and an
+        Enterprise dashboard to manage it all.
+      </p>
+    </header>
+
+    <div class="section_icons">
+      <span class="system_icon"><i class="fa-solid fa-users"></i></span>
+    </div>
+
+    <p class="workshop_desc">
+      License the Architect course for your team, add the Masterclass
+      Curriculum for anyone who wants it, and manage members, seats,
+      and progress from one dashboard — buy exactly as many seats as
+      your team needs, starting at 5.
+    </p>
+
+    <div class="section_cta">
+      <a href="/teams/" class="button button_purple">See Team Pricing</a>
+    </div>
+  </div>
+</div>

--- a/layouts/partials/index/teams.html
+++ b/layouts/partials/index/teams.html
@@ -1,4 +1,4 @@
-<div class="index_workshops">
+<div class="index_workshops index_teams">
   <div class="wrapper">
     <header class="heading">
       <h3>PostgreSQL Expertise For Your Whole Team</h3>

--- a/layouts/partials/masterclass/pricing.html
+++ b/layouts/partials/masterclass/pricing.html
@@ -73,5 +73,15 @@
         </div>
       </li>
     </ul>
+
+    <header class="heading">
+      <p class="lightpurple">
+        Bringing the whole Masterclass Curriculum to your team as a
+        shared cohort experience is where it earns its price most.
+      </p>
+      <div class="cta_row">
+        <a href="/teams/" class="button button_transparent">Attend as a Team →</a>
+      </div>
+    </header>
   </div>
 </div>

--- a/themes/taop/layouts/partials/footer.html
+++ b/themes/taop/layouts/partials/footer.html
@@ -26,6 +26,8 @@
              <dd>The <a href="/book/contents/">book table of contents</a> lists all 9 parts and 57 chapters — from SQL foundations through advanced query patterns and data architecture. The <a href="/course/contents/">course curriculum</a> covers 6 courses and 48 modules across Core, Advanced, and Architect tiers, with hands-on SQL labs on real datasets.</dd>
              <dt>Is SQL still relevant now that AI writes queries?</dt>
              <dd>Yes — <a href="/sql-and-ai/">here is why understanding SQL matters more than ever</a>, even when AI generates the code.</dd>
+             <dt>Do you offer team or enterprise pricing?</dt>
+             <dd>Yes — <a href="/teams/">see the Team page</a> for per-member Architect course licensing, an optional Masterclass Curriculum add-on, and a dashboard to manage your whole team.</dd>
              <dt>Is there any DRM?</dt>
 	             <dd>No. There isn't even watermarking on the PDF. You own what you buy. The sources of data selected for the book are all available with Open Data types of licenses, and the book itself is copyright Dimitri Fontaine. All rights reserved.</dd>
 	             <dt>Any other questions?</dt>

--- a/themes/taop/static/css/style.css
+++ b/themes/taop/static/css/style.css
@@ -4012,6 +4012,21 @@ body.newsletter .index_hero .hero_cta .button.button_outline:hover {
 .index_workshops .workshop_desc {
   color: rgba(255,255,255,0.9);
 }
+.index_teams {
+  background: #f8f7f9;
+}
+.index_teams .heading h3 {
+  color: #372649;
+}
+.index_teams .lightpurple {
+  color: #67527a;
+}
+.index_teams .workshop_desc {
+  color: #67527a;
+}
+.index_teams .section_icons {
+  color: #60b2d3;
+}
 .index_courses .tier_preview {
   list-style: none;
   padding: 0;
@@ -4059,10 +4074,20 @@ body.newsletter .index_hero .hero_cta .button.button_outline:hover {
   background: #60b2d3;
   border-color: #372649;
 }
-.index_workshops .button.button_purple:hover, 
+.index_workshops .button.button_purple:hover,
 .index_workshops .section_cta .button.button_purple:hover {
   background: #372649;
   border-color: #60b2d3;
+}
+.index_teams .button.button_purple,
+.index_teams .section_cta .button.button_purple {
+  background: #372649;
+  border-color: #60b2d3;
+}
+.index_teams .button.button_purple:hover,
+.index_teams .section_cta .button.button_purple:hover {
+  background: #60b2d3;
+  border-color: #372649;
 }
 
 .index_ecosystem {


### PR DESCRIPTION
## Summary

- Rebuild `/teams/` from scratch as a real, self-serve enterprise/team offering page: hero, four-step onboarding, pricing ($1,995/year for 5 Architect seats, $399/seat after, $1,495/team-member Masterclass Curriculum add-on), promoted Masterclass Curriculum section, dashboard feature grid, FAQ, final CTA — all built from real business facts, reusing existing site components (`.price_list`, `.value_list`, `.course_faq`, `.system_flow`, `.section_icons`).
- Link `/teams/` sitewide: footer FAQ entry, two new sections on `/app/` (dashboard exercises/quizzes/leaderboard, team dashboard), a button on the course pricing page, a button on the masterclass pricing page, and a new homepage teaser section before "One System, One Learning Path".
- Polish `/app/`: reordered sections (team dashboard now follows "Track your progress"), fixed a background-color collision so every section alternates cleanly, restored the intended 3-column feature grid, fixed icon/title row layout and small-caps styling on dashboard cards, centered the team CTA button, and added a working email signup form ("Try it yourself, create a free account now") to the live-SQL section using the real magic-link login endpoint.
- Fixed a background-color collision on the homepage between "Ready to master PostgreSQL?" and the new team teaser section, and reversed the team teaser's button colors so it doesn't read identically to the real workshops section button.

## Test plan

- [x] `hugo --minify --cleanDestinationDir` builds cleanly
- [x] `lychee --offline --root-dir docs docs/` reports 0 broken links
- [x] Verified computed styles (backgrounds, alignment, grid columns, form action) via the browser pane at each step